### PR TITLE
Make characteristics available per working mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ export default function App() {
     const { workingMode, setWorkingMode } = WorkingModeStore.use();
 
     useEffect(() => {
-        setCurrentTab(workingMode === "" ? TABS.SELECT_MODE : TABS.HOMEPAGE);
+        setCurrentTab(!workingMode ? TABS.SELECT_MODE : TABS.HOMEPAGE);
     }, [workingMode]);
 
     return (
@@ -34,9 +34,7 @@ export default function App() {
             <Tabs
                 value={currentTab}
                 onValueChange={tab => setCurrentTab(tab as TABS)}
-                defaultValue={
-                    workingMode === "" ? TABS.SELECT_MODE : TABS.HOMEPAGE
-                }
+                defaultValue={!workingMode ? TABS.SELECT_MODE : TABS.HOMEPAGE}
                 className="w-full flex flex-col items-center flex-grow"
             >
                 <TabsContent

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, Suspense, lazy, useEffect } from "react";
+import React, { useState, Suspense, lazy } from "react";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import { GlobalToolbar } from "@/components/toolbar/toolbar";
 import { cn } from "@/lib/utils/shadcn";
@@ -18,12 +18,8 @@ const enum TABS {
 }
 
 export default function App() {
-    const [currentTab, setCurrentTab] = useState<TABS>(TABS.HOMEPAGE);
-    const { workingMode, setWorkingMode } = WorkingModeStore.use();
-
-    useEffect(() => {
-        setCurrentTab(!workingMode ? TABS.SELECT_MODE : TABS.HOMEPAGE);
-    }, [workingMode]);
+    const [currentTab, setCurrentTab] = useState<TABS>(TABS.SELECT_MODE);
+    const { setWorkingMode } = WorkingModeStore.use();
 
     return (
         <main
@@ -34,7 +30,6 @@ export default function App() {
             <Tabs
                 value={currentTab}
                 onValueChange={tab => setCurrentTab(tab as TABS)}
-                defaultValue={!workingMode ? TABS.SELECT_MODE : TABS.HOMEPAGE}
                 className="w-full flex flex-col items-center flex-grow"
             >
                 <TabsContent

--- a/src/components/dialogs/marking-characteristics/exportMarkingCharacteristicsWithDialog.ts
+++ b/src/components/dialogs/marking-characteristics/exportMarkingCharacteristicsWithDialog.ts
@@ -56,7 +56,7 @@ export async function exportMarkingCharacteristicsWithDialog() {
             canCreateDirectories: true,
             defaultPath: await join(
                 await desktopDir(),
-                `marking-characteristics-${WorkingModeStore.state.workingMode?.toLowerCase().replace(" ", "_")}.json`
+                `marking-characteristics-${WorkingModeStore.state.workingMode?.toLowerCase()}.json`
             ),
         });
 

--- a/src/components/dialogs/marking-characteristics/exportMarkingCharacteristicsWithDialog.ts
+++ b/src/components/dialogs/marking-characteristics/exportMarkingCharacteristicsWithDialog.ts
@@ -6,6 +6,7 @@ import { showErrorDialog } from "@/lib/errors/showErrorDialog";
 import { desktopDir, join } from "@tauri-apps/api/path";
 import { MarkingCharacteristic } from "@/lib/markings/MarkingCharacteristic";
 import { MarkingCharacteristicsStore } from "@/lib/stores/MarkingCharacteristics/MarkingCharacteristics";
+import { WorkingModeStore } from "@/lib/stores/WorkingMode";
 
 type SoftwareInfo = {
     name: string;
@@ -31,7 +32,9 @@ async function getData(): Promise<string> {
         },
         data: {
             markingCharacteristics:
-                MarkingCharacteristicsStore.state.characteristics,
+                MarkingCharacteristicsStore.state.characteristics.filter(
+                    c => c.category === WorkingModeStore.state.workingMode
+                ),
         },
     };
 
@@ -53,7 +56,7 @@ export async function exportMarkingCharacteristicsWithDialog() {
             canCreateDirectories: true,
             defaultPath: await join(
                 await desktopDir(),
-                "marking-characteristics.json"
+                `marking-characteristics-${WorkingModeStore.state.workingMode?.toLowerCase().replace(" ", "_")}.json`
             ),
         });
 

--- a/src/components/dialogs/marking-characteristics/importMarkingCharacteristicsWithDialog.ts
+++ b/src/components/dialogs/marking-characteristics/importMarkingCharacteristicsWithDialog.ts
@@ -43,9 +43,13 @@ export async function loadMarkingCharacteristicsData(filePath: string) {
 
     // TODO: fix this - create a working mode when we allow the creation of new ones
     const workingModesFromData =
-        fileContentJson.data.markingCharacteristics
-            ?.map(item => item.category)
-            .flat() || [];
+        Array.from(
+            new Set(
+                fileContentJson.data.markingCharacteristics
+                    ?.map(item => item.category)
+                    .flat()
+            )
+        ) || [];
     const supportedWorkingModes = Object.keys(WORKING_MODE);
 
     if (

--- a/src/components/dialogs/marking-characteristics/importMarkingCharacteristicsWithDialog.ts
+++ b/src/components/dialogs/marking-characteristics/importMarkingCharacteristicsWithDialog.ts
@@ -10,6 +10,7 @@ import { MarkingCharacteristicsStore } from "@/lib/stores/MarkingCharacteristics
 import { MarkingCharacteristicsExportObject } from "@/components/dialogs/marking-characteristics/exportMarkingCharacteristicsWithDialog";
 import { validateFileData } from "@/lib/utils/viewport/loadMarkingsData";
 import { WORKING_MODE } from "@/views/selectMode";
+import { WorkingModeStore } from "@/lib/stores/WorkingMode";
 
 export async function loadMarkingCharacteristicsData(filePath: string) {
     const fileContentString = await readTextFile(filePath);
@@ -41,14 +42,14 @@ export async function loadMarkingCharacteristicsData(filePath: string) {
     }
 
     // TODO: fix this - create a working mode when we allow the creation of new ones
-    const availableWorkingModesFromData =
+    const workingModesFromData =
         fileContentJson.data.markingCharacteristics
             ?.map(item => item.category)
             .flat() || [];
     const supportedWorkingModes = Object.keys(WORKING_MODE);
 
     if (
-        availableWorkingModesFromData.filter(
+        workingModesFromData.filter(
             mode => !supportedWorkingModes.includes(mode)
         ).length
     ) {
@@ -82,6 +83,10 @@ export async function loadMarkingCharacteristicsData(filePath: string) {
             }
         );
         if (!confirmed) return;
+    }
+
+    if (workingModesFromData.length === 1 && workingModesFromData[0]) {
+        WorkingModeStore.actions.setWorkingMode(workingModesFromData[0]);
     }
 
     MarkingCharacteristicsStore.actions.characteristics.addMany(

--- a/src/components/dialogs/marking-characteristics/importMarkingCharacteristicsWithDialog.ts
+++ b/src/components/dialogs/marking-characteristics/importMarkingCharacteristicsWithDialog.ts
@@ -9,6 +9,7 @@ import { readTextFile } from "@tauri-apps/plugin-fs";
 import { MarkingCharacteristicsStore } from "@/lib/stores/MarkingCharacteristics/MarkingCharacteristics";
 import { MarkingCharacteristicsExportObject } from "@/components/dialogs/marking-characteristics/exportMarkingCharacteristicsWithDialog";
 import { validateFileData } from "@/lib/utils/viewport/loadMarkingsData";
+import { WORKING_MODE } from "@/views/selectMode";
 
 export async function loadMarkingCharacteristicsData(filePath: string) {
     const fileContentString = await readTextFile(filePath);
@@ -37,6 +38,27 @@ export async function loadMarkingCharacteristicsData(filePath: string) {
             }
         );
         if (!confirmed) return;
+    }
+
+    // TODO: fix this - create a working mode when we allow the creation of new ones
+    const availableWorkingModesFromData =
+        fileContentJson.data.markingCharacteristics
+            ?.map(item => item.category)
+            .flat() || [];
+    const supportedWorkingModes = Object.keys(WORKING_MODE);
+
+    if (
+        availableWorkingModesFromData.filter(
+            mode => !supportedWorkingModes.includes(mode)
+        ).length
+    ) {
+        showErrorDialog(
+            t(
+                "You are trying to load marking characteristics for a non-existing working mode.",
+                { ns: "dialog" }
+            )
+        );
+        return;
     }
 
     const characteristics = fileContentJson.data.markingCharacteristics;

--- a/src/components/dialogs/marking-characteristics/marking-characteristics-dialog-portal.tsx
+++ b/src/components/dialogs/marking-characteristics/marking-characteristics-dialog-portal.tsx
@@ -34,7 +34,7 @@ import { WorkingModeStore } from "@/lib/stores/WorkingMode";
 function MarkingCharacteristicsDialogPortal() {
     const { t } = useTranslation();
 
-    const { workingMode } = WorkingModeStore.state;
+    const workingMode = WorkingModeStore.use(state => state.workingMode);
 
     return (
         <DialogPortal>

--- a/src/components/dialogs/marking-characteristics/marking-characteristics-dialog-portal.tsx
+++ b/src/components/dialogs/marking-characteristics/marking-characteristics-dialog-portal.tsx
@@ -14,7 +14,6 @@ import {
     defaultBackgroundColor,
     defaultSize,
     defaultTextColor,
-    WORKING_MODE,
 } from "@/lib/markings/MarkingCharacteristic";
 import { Download, Plus, Upload, X } from "lucide-react";
 import { ICON } from "@/lib/utils/const";
@@ -30,9 +29,12 @@ import {
 import { exportMarkingCharacteristicsWithDialog } from "@/components/dialogs/marking-characteristics/exportMarkingCharacteristicsWithDialog";
 import { importMarkingCharacteristicsWithDialog } from "@/components/dialogs/marking-characteristics/importMarkingCharacteristicsWithDialog";
 import { useTranslation } from "react-i18next";
+import { WorkingModeStore } from "@/lib/stores/WorkingMode";
 
 function MarkingCharacteristicsDialogPortal() {
     const { t } = useTranslation();
+
+    const { workingMode } = WorkingModeStore.state;
 
     return (
         <DialogPortal>
@@ -86,8 +88,7 @@ function MarkingCharacteristicsDialogPortal() {
                                                                 defaultTextColor,
                                                             size: defaultSize,
                                                             category:
-                                                                // TODO Get current working mode
-                                                                WORKING_MODE.FINGERPRINT,
+                                                                workingMode,
                                                         }
                                                     )
                                                 }

--- a/src/components/dialogs/marking-characteristics/marking-characteristics-dialog-portal.tsx
+++ b/src/components/dialogs/marking-characteristics/marking-characteristics-dialog-portal.tsx
@@ -88,7 +88,7 @@ function MarkingCharacteristicsDialogPortal() {
                                                                 defaultTextColor,
                                                             size: defaultSize,
                                                             category:
-                                                                workingMode,
+                                                                workingMode!,
                                                         }
                                                     )
                                                 }
@@ -139,6 +139,11 @@ function MarkingCharacteristicsDialogPortal() {
                                 strokeWidth={ICON.STROKE_WIDTH}
                             />
                         </Toggle>
+
+                        <span className="ml-1">
+                            {t("Working mode")}:{" "}
+                            <span className="font-bold">{workingMode}</span>
+                        </span>
                     </div>
 
                     <div>

--- a/src/components/dialogs/marking-characteristics/marking-characteristics-table.tsx
+++ b/src/components/dialogs/marking-characteristics/marking-characteristics-table.tsx
@@ -1,6 +1,5 @@
 import { cn } from "@/lib/utils/shadcn";
 import { Input } from "@/components/ui/input";
-import { WORKING_MODE } from "@/lib/markings/MarkingCharacteristic";
 import { t } from "i18next";
 import { useDebouncedCallback } from "use-debounce";
 import { MarkingCharacteristicsStore } from "@/lib/stores/MarkingCharacteristics/MarkingCharacteristics";
@@ -9,11 +8,12 @@ import { Trash2 } from "lucide-react";
 import { ICON } from "@/lib/utils/const";
 import { Toggle } from "@/components/ui/toggle";
 import { CANVAS_ID } from "@/components/pixi/canvas/hooks/useCanvasContext";
+import { WorkingModeStore } from "@/lib/stores/WorkingMode";
 
 function MarkingCharacteristicsTable() {
     const characteristics = MarkingCharacteristicsStore.use(state =>
         state.characteristics.filter(
-            c => c.category === WORKING_MODE.FINGERPRINT
+            c => c.category === WorkingModeStore.state.workingMode
         )
     );
 

--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -11,7 +11,7 @@ import { WorkingModeStore } from "@/lib/stores/WorkingMode";
 
 export function Menu() {
     const { t } = useTranslation();
-    const { workingMode } = WorkingModeStore.use();
+    const workingMode = WorkingModeStore.use(state => state.workingMode);
 
     return (
         <Menubar
@@ -29,7 +29,7 @@ export function Menu() {
                     />
                 </div>
                 <SettingsMenu />
-                {workingMode !== "" && (
+                {workingMode && (
                     <>
                         <ModeMenu />
                         <Dialog>

--- a/src/components/pixi/viewport/event-handlers/mousedown.event.ts
+++ b/src/components/pixi/viewport/event-handlers/mousedown.event.ts
@@ -10,6 +10,7 @@ import { PointMarking } from "@/lib/markings/PointMarking";
 import { RayMarking } from "@/lib/markings/RayMarking";
 import { LineSegmentMarking } from "@/lib/markings/LineSegmentMarking";
 import { MarkingCharacteristicsStore } from "@/lib/stores/MarkingCharacteristics/MarkingCharacteristics";
+import { WorkingModeStore } from "@/lib/stores/WorkingMode";
 import { ViewportHandlerParams, getNormalizedMousePosition } from "./utils";
 
 let onMouseMove: (e: FederatedPointerEvent) => void = () => {};

--- a/src/components/pixi/viewport/event-handlers/mousedown.event.ts
+++ b/src/components/pixi/viewport/event-handlers/mousedown.event.ts
@@ -209,10 +209,12 @@ export const handleRMBDown = (
 
     if (cursorMode === CURSOR_MODES.MARKING) {
         const markingType = DashboardToolbarStore.state.settings.marking.type;
+        const workingMode = WorkingModeStore.state.workingMode!;
 
         const { id: characteristicId } =
             MarkingCharacteristicsStore.actions.activeCharacteristics.getActiveCharacteristicByType(
-                markingType
+                markingType,
+                workingMode
             );
 
         switch (markingType) {

--- a/src/components/toolbar/toolbar.tsx
+++ b/src/components/toolbar/toolbar.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 import { Toggle } from "@/components/ui/toggle";
 import { cn } from "@/lib/utils/shadcn";
-import { HTMLAttributes } from "react";
+import { HTMLAttributes, useEffect } from "react";
 import {
     CURSOR_MODES,
     DashboardToolbarStore,
@@ -33,6 +33,7 @@ import {
     defaultSize,
     defaultTextColor,
 } from "@/lib/markings/MarkingCharacteristic";
+import { WorkingModeStore } from "@/lib/stores/WorkingMode";
 import { ToolbarGroup } from "./group";
 import { ToggleGroup, ToggleGroupItem } from "../ui/toggle-group";
 import { Input } from "../ui/input";
@@ -44,6 +45,7 @@ export function GlobalToolbar({ className, ...props }: GlobalToolbarProps) {
     const { mode: cursorMode } = DashboardToolbarStore.use(
         state => state.settings.cursor
     );
+
     const { locked: isViewportLocked, scaleSync: isViewportScaleSync } =
         DashboardToolbarStore.use(state => state.settings.viewport);
 
@@ -55,13 +57,19 @@ export function GlobalToolbar({ className, ...props }: GlobalToolbarProps) {
         state => state.activeCharacteristics
     );
 
+    const { workingMode } = WorkingModeStore.state;
+
     const selectedCharacteristic = activeCharacteristics.find(
-        characteristic => characteristic.type === selectedMarkingType
+        characteristic =>
+            characteristic.type === selectedMarkingType &&
+            characteristic.category === workingMode
     );
 
     const markingTypeCharacteristics = MarkingCharacteristicsStore.use(state =>
         state.characteristics.filter(
-            characteristic => characteristic.type === selectedMarkingType
+            characteristic =>
+                characteristic.type === selectedMarkingType &&
+                characteristic.category === workingMode
         )
     );
 
@@ -164,7 +172,9 @@ export function GlobalToolbar({ className, ...props }: GlobalToolbarProps) {
                         title={`${t("Marking.Keys.type.Keys.point", { ns: "object" })} (1)`}
                         disabled={
                             !activeCharacteristics.some(
-                                x => x.type === MARKING_TYPE.POINT
+                                x =>
+                                    x.type === MARKING_TYPE.POINT &&
+                                    x.category === workingMode
                             )
                         }
                         onClick={() => {
@@ -185,7 +195,9 @@ export function GlobalToolbar({ className, ...props }: GlobalToolbarProps) {
                         }}
                         disabled={
                             !activeCharacteristics.some(
-                                x => x.type === MARKING_TYPE.RAY
+                                x =>
+                                    x.type === MARKING_TYPE.RAY &&
+                                    x.category === workingMode
                             )
                         }
                     >
@@ -204,7 +216,9 @@ export function GlobalToolbar({ className, ...props }: GlobalToolbarProps) {
                         }}
                         disabled={
                             !activeCharacteristics.some(
-                                x => x.type === MARKING_TYPE.LINE_SEGMENT
+                                x =>
+                                    x.type === MARKING_TYPE.LINE_SEGMENT &&
+                                    x.category === workingMode
                             )
                         }
                     >

--- a/src/components/toolbar/toolbar.tsx
+++ b/src/components/toolbar/toolbar.tsx
@@ -57,7 +57,7 @@ export function GlobalToolbar({ className, ...props }: GlobalToolbarProps) {
         state => state.activeCharacteristics
     );
 
-    const { workingMode } = WorkingModeStore.state;
+    const workingMode = WorkingModeStore.use(state => state.workingMode);
 
     const selectedCharacteristic = activeCharacteristics.find(
         characteristic =>

--- a/src/components/toolbar/toolbar.tsx
+++ b/src/components/toolbar/toolbar.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { Toggle } from "@/components/ui/toggle";
 import { cn } from "@/lib/utils/shadcn";
 import { HTMLAttributes } from "react";
@@ -45,6 +44,7 @@ export function GlobalToolbar({ className, ...props }: GlobalToolbarProps) {
     const { mode: cursorMode } = DashboardToolbarStore.use(
         state => state.settings.cursor
     );
+    const workingMode = WorkingModeStore.use(state => state.workingMode);
 
     const { locked: isViewportLocked, scaleSync: isViewportScaleSync } =
         DashboardToolbarStore.use(state => state.settings.viewport);
@@ -57,21 +57,23 @@ export function GlobalToolbar({ className, ...props }: GlobalToolbarProps) {
         state => state.activeCharacteristics
     );
 
-    const workingMode = WorkingModeStore.use(state => state.workingMode);
-
     const selectedCharacteristic = activeCharacteristics.find(
         characteristic =>
             characteristic.type === selectedMarkingType &&
             characteristic.category === workingMode
     );
 
-    const markingTypeCharacteristics = MarkingCharacteristicsStore.use(state =>
-        state.characteristics.filter(
-            characteristic =>
-                characteristic.type === selectedMarkingType &&
-                characteristic.category === workingMode
-        )
-    );
+    const availableMarkingCharacteristicsForWorkingMode =
+        MarkingCharacteristicsStore.use(state =>
+            state.characteristics.filter(
+                characteristic => characteristic.category === workingMode
+            )
+        );
+
+    const markingTypeCharacteristics =
+        availableMarkingCharacteristicsForWorkingMode.filter(
+            characteristic => characteristic.type === selectedMarkingType
+        );
 
     const setCharacteristic = useDebouncedCallback(
         (id, value) =>
@@ -137,7 +139,7 @@ export function GlobalToolbar({ className, ...props }: GlobalToolbarProps) {
                             "w-36 overflow-hidden text-ellipsis whitespace-nowrap",
                             className
                         )}
-                        disabled={!selectedCharacteristic}
+                        disabled={!markingTypeCharacteristics.length}
                     >
                         {selectedCharacteristic?.name}
                     </DropdownMenuTrigger>
@@ -149,7 +151,8 @@ export function GlobalToolbar({ className, ...props }: GlobalToolbarProps) {
                                     onClick={() => {
                                         MarkingCharacteristicsStore.actions.activeCharacteristics.setActiveCharacteristicByType(
                                             selectedMarkingType,
-                                            characteristic.id
+                                            characteristic.id,
+                                            workingMode!
                                         );
                                     }}
                                 >
@@ -171,10 +174,8 @@ export function GlobalToolbar({ className, ...props }: GlobalToolbarProps) {
                         value={MARKING_TYPE.POINT}
                         title={`${t("Marking.Keys.type.Keys.point", { ns: "object" })} (1)`}
                         disabled={
-                            !activeCharacteristics.some(
-                                x =>
-                                    x.type === MARKING_TYPE.POINT &&
-                                    x.category === workingMode
+                            !availableMarkingCharacteristicsForWorkingMode.some(
+                                x => x.type === MARKING_TYPE.POINT
                             )
                         }
                         onClick={() => {
@@ -194,10 +195,8 @@ export function GlobalToolbar({ className, ...props }: GlobalToolbarProps) {
                             );
                         }}
                         disabled={
-                            !activeCharacteristics.some(
-                                x =>
-                                    x.type === MARKING_TYPE.RAY &&
-                                    x.category === workingMode
+                            !availableMarkingCharacteristicsForWorkingMode.some(
+                                x => x.type === MARKING_TYPE.RAY
                             )
                         }
                     >
@@ -215,10 +214,8 @@ export function GlobalToolbar({ className, ...props }: GlobalToolbarProps) {
                             );
                         }}
                         disabled={
-                            !activeCharacteristics.some(
-                                x =>
-                                    x.type === MARKING_TYPE.LINE_SEGMENT &&
-                                    x.category === workingMode
+                            !availableMarkingCharacteristicsForWorkingMode.some(
+                                x => x.type === MARKING_TYPE.LINE_SEGMENT
                             )
                         }
                     >

--- a/src/components/toolbar/toolbar.tsx
+++ b/src/components/toolbar/toolbar.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 import { Toggle } from "@/components/ui/toggle";
 import { cn } from "@/lib/utils/shadcn";
-import { HTMLAttributes, useEffect } from "react";
+import { HTMLAttributes } from "react";
 import {
     CURSOR_MODES,
     DashboardToolbarStore,

--- a/src/lib/hooks/useKeyboardShortcuts.tsx
+++ b/src/lib/hooks/useKeyboardShortcuts.tsx
@@ -1,4 +1,6 @@
 import { MARKING_TYPE } from "@/lib/markings/MarkingBase";
+import { MarkingCharacteristicsStore } from "@/lib/stores/MarkingCharacteristics/MarkingCharacteristics";
+import { WorkingModeStore } from "@/lib/stores/WorkingMode";
 import {
     CURSOR_MODES,
     DashboardToolbarStore,
@@ -17,6 +19,17 @@ export const useKeyboardShortcuts = () => {
     const { setSelectedMarkingType } = markingActions;
     const { setCursorMode } = cursorActions;
     const { toggleLockedViewport, toggleLockScaleSync } = viewportActions;
+    const { workingMode } = WorkingModeStore.state;
+
+    function isMarkingTypeAvailable(markingType: MARKING_TYPE) {
+        return (
+            MarkingCharacteristicsStore.state.characteristics.filter(
+                characteristic =>
+                    characteristic.category === workingMode &&
+                    characteristic.type === markingType
+            ).length > 0
+        );
+    }
 
     useKeyDown(() => {
         document.dispatchEvent(
@@ -33,14 +46,17 @@ export const useKeyboardShortcuts = () => {
     }, ["F2"]);
 
     useKeyDown(() => {
+        if (!isMarkingTypeAvailable(MARKING_TYPE.POINT)) return;
         setSelectedMarkingType(MARKING_TYPE.POINT);
     }, ["1"]);
 
     useKeyDown(() => {
+        if (!isMarkingTypeAvailable(MARKING_TYPE.RAY)) return;
         setSelectedMarkingType(MARKING_TYPE.RAY);
     }, ["2"]);
 
     useKeyDown(() => {
+        if (!isMarkingTypeAvailable(MARKING_TYPE.LINE_SEGMENT)) return;
         setSelectedMarkingType(MARKING_TYPE.LINE_SEGMENT);
     }, ["3"]);
 

--- a/src/lib/locales/en/dialog.ts
+++ b/src/lib/locales/en/dialog.ts
@@ -19,6 +19,8 @@ const d: Dictionary = {
     "The markings data was created with a different working mode ({{mode}}). Change the working mode to ({{mode}}) to load the data.":
         "The markings data was created with a different working mode ({{mode}}). Change the working mode to ({{mode}}) to load the data.",
     "Please select your working mode": "Please select your working mode",
+    "You are trying to load marking characteristics for a non-existing working mode.":
+        "You are trying to load marking characteristics for a non-existing working mode.",
 };
 
 export default d;

--- a/src/lib/locales/pl/dialog.ts
+++ b/src/lib/locales/pl/dialog.ts
@@ -19,6 +19,8 @@ const d: Dictionary = {
     "The markings data was created with a different working mode ({{mode}}). Change the working mode to ({{mode}}) to load the data.":
         "Dane dotyczące adnotacji zostały utworzone w innym trybie pracy ({{mode}}). Zmień tryb pracy na ({{mode}}), aby załadować dane.",
     "Please select your working mode": "Proszę wybrać tryb pracy",
+    "You are trying to load marking characteristics for a non-existing working mode.":
+        "Próbujesz załadować charakterystyki dla nieistniejącego trybu pracy.",
 };
 
 export default d;

--- a/src/lib/locales/translation.ts
+++ b/src/lib/locales/translation.ts
@@ -86,6 +86,7 @@ export type i18nDialog = Recordify<
     | "Missing marking characteristics detected"
     | "The markings data was created with a different working mode ({{mode}}). Change the working mode to ({{mode}}) to load the data."
     | "Please select your working mode"
+    | "You are trying to load marking characteristics for a non-existing working mode."
 >;
 
 export type i18nDescription = Recordify<"Prerendering radius">;

--- a/src/lib/markings/MarkingCharacteristic.ts
+++ b/src/lib/markings/MarkingCharacteristic.ts
@@ -9,7 +9,7 @@ export interface MarkingCharacteristic {
     backgroundColor: ColorSource;
     textColor: ColorSource;
     size: number;
-    category: WORKING_MODE | null;
+    category: WORKING_MODE;
 }
 
 export const defaultBackgroundColor = "#61BD67";

--- a/src/lib/markings/MarkingCharacteristic.ts
+++ b/src/lib/markings/MarkingCharacteristic.ts
@@ -1,12 +1,6 @@
 import { ColorSource } from "pixi.js";
 import { MARKING_TYPE } from "@/lib/markings/MarkingBase";
-
-// TODO docelowo to powinno być dodane przez Marcela w https://github.com/BiometricsUBB/Biometrics-Studio/pull/6 wtedy należy to przepiąć
-export enum WORKING_MODE {
-    FINGERPRINT = "FINGERPRINT",
-    EAR = "EAR",
-    SHOEPRINT = "SHOEPRINT",
-}
+import { WORKING_MODE } from "@/views/selectMode";
 
 export interface MarkingCharacteristic {
     id: string;
@@ -15,7 +9,7 @@ export interface MarkingCharacteristic {
     backgroundColor: ColorSource;
     textColor: ColorSource;
     size: number;
-    category: WORKING_MODE;
+    category: WORKING_MODE | null;
 }
 
 export const defaultBackgroundColor = "#61BD67";

--- a/src/lib/stores/MarkingCharacteristics/MarkingCharacteristics.ts
+++ b/src/lib/stores/MarkingCharacteristics/MarkingCharacteristics.ts
@@ -74,7 +74,9 @@ class StoreClass {
 
                 if (
                     !this.state.activeCharacteristics.find(
-                        x => x.type === characteristic.type
+                        x =>
+                            x.type === characteristic.type &&
+                            x.category === WorkingModeStore.state.workingMode
                     )
                 ) {
                     this.state.set(draft => {
@@ -107,7 +109,10 @@ class StoreClass {
                     characteristics.forEach(characteristic => {
                         if (
                             !draft.activeCharacteristics.find(
-                                x => x.type === characteristic.type
+                                x =>
+                                    x.type === characteristic.type &&
+                                    x.category ===
+                                        WorkingModeStore.state.workingMode
                             )
                         ) {
                             draft.activeCharacteristics.push(characteristic);
@@ -141,7 +146,9 @@ class StoreClass {
                         );
 
                     const activeCharacteristic = draft.characteristics.find(
-                        x => x.type === type
+                        x =>
+                            x.type === type &&
+                            x.category === WorkingModeStore.state.workingMode
                     );
 
                     if (activeCharacteristic) {

--- a/src/lib/stores/MarkingCharacteristics/MarkingCharacteristics.ts
+++ b/src/lib/stores/MarkingCharacteristics/MarkingCharacteristics.ts
@@ -19,11 +19,8 @@ class StoreClass {
             setActiveCharacteristicByType: (
                 type: MarkingCharacteristic["type"],
                 characteristicId: MarkingCharacteristic["id"],
-                workingMode?: WORKING_MODE
+                workingMode: WORKING_MODE
             ) => {
-                if (!workingMode) {
-                    workingMode = WorkingModeStore.state.workingMode!;
-                }
                 const newActiveCharacteristic = this.state.characteristics.find(
                     characteristic =>
                         characteristic.id === characteristicId &&

--- a/src/lib/stores/MarkingCharacteristics/MarkingCharacteristics.ts
+++ b/src/lib/stores/MarkingCharacteristics/MarkingCharacteristics.ts
@@ -19,10 +19,10 @@ class StoreClass {
             setActiveCharacteristicByType: (
                 type: MarkingCharacteristic["type"],
                 characteristicId: MarkingCharacteristic["id"],
-                workingMode?: WORKING_MODE | null
+                workingMode?: WORKING_MODE
             ) => {
                 if (!workingMode) {
-                    workingMode = WorkingModeStore.state.workingMode;
+                    workingMode = WorkingModeStore.state.workingMode!;
                 }
                 const newActiveCharacteristic = this.state.characteristics.find(
                     characteristic =>
@@ -47,11 +47,11 @@ class StoreClass {
             },
             getActiveCharacteristicByType: (
                 type: MarkingCharacteristic["type"],
-                workingMode?: WORKING_MODE | null
+                workingMode?: WORKING_MODE
             ) => {
-                if (!workingMode) {
-                    workingMode = WorkingModeStore.state.workingMode;
-                }
+                if (!workingMode)
+                    workingMode = WorkingModeStore.state.workingMode!;
+
                 const characteristic = this.state.characteristics.find(
                     characteristic =>
                         characteristic.id ===

--- a/src/lib/stores/MarkingCharacteristics/MarkingCharacteristics.ts
+++ b/src/lib/stores/MarkingCharacteristics/MarkingCharacteristics.ts
@@ -3,6 +3,8 @@
 import { MarkingCharacteristic } from "@/lib/markings/MarkingCharacteristic";
 import { MarkingsStore } from "@/lib/stores/Markings";
 import { CANVAS_ID } from "@/components/pixi/canvas/hooks/useCanvasContext";
+import { WORKING_MODE } from "@/views/selectMode";
+import { WorkingModeStore } from "@/lib/stores/WorkingMode";
 import { _useMarkingCharacteristicsStore as useStore } from "./MarkingCharacteristics.store";
 
 class StoreClass {
@@ -16,10 +18,16 @@ class StoreClass {
         activeCharacteristics: {
             setActiveCharacteristicByType: (
                 type: MarkingCharacteristic["type"],
-                characteristicId: MarkingCharacteristic["id"]
+                characteristicId: MarkingCharacteristic["id"],
+                workingMode?: WORKING_MODE | null
             ) => {
+                if (!workingMode) {
+                    workingMode = WorkingModeStore.state.workingMode;
+                }
                 const newActiveCharacteristic = this.state.characteristics.find(
-                    characteristic => characteristic.id === characteristicId
+                    characteristic =>
+                        characteristic.id === characteristicId &&
+                        characteristic.category === workingMode
                 );
 
                 if (!newActiveCharacteristic) {
@@ -38,14 +46,18 @@ class StoreClass {
                 });
             },
             getActiveCharacteristicByType: (
-                type: MarkingCharacteristic["type"]
+                type: MarkingCharacteristic["type"],
+                workingMode?: WORKING_MODE | null
             ) => {
+                if (!workingMode) {
+                    workingMode = WorkingModeStore.state.workingMode;
+                }
                 const characteristic = this.state.characteristics.find(
                     characteristic =>
                         characteristic.id ===
                         this.state.activeCharacteristics.find(
-                            x => x.type === type
-                        )!.id
+                            x => x.type === type && x.category === workingMode
+                        )?.id
                 );
 
                 if (!characteristic) {

--- a/src/lib/stores/WorkingMode/WorkingMode.store.ts
+++ b/src/lib/stores/WorkingMode/WorkingMode.store.ts
@@ -3,13 +3,13 @@ import { devtools, persist } from "zustand/middleware";
 import { WORKING_MODE } from "@/views/selectMode";
 
 type State = {
-    workingMode: WORKING_MODE | "";
-    setWorkingMode: (mode: WORKING_MODE | "") => void;
+    workingMode: WORKING_MODE | null;
+    setWorkingMode: (mode: WORKING_MODE | null) => void;
     resetWorkingMode: () => void;
 };
 
 const INITIAL_STATE: Pick<State, "workingMode"> = {
-    workingMode: "",
+    workingMode: null,
 };
 
 const useWorkingModeStore = create<State>()(

--- a/src/lib/stores/WorkingMode/WorkingMode.store.ts
+++ b/src/lib/stores/WorkingMode/WorkingMode.store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { createJSONStorage, devtools, persist } from "zustand/middleware";
+import { createJSONStorage, devtools } from "zustand/middleware";
 import { WORKING_MODE } from "@/views/selectMode";
 import { createStore, Store } from "@tauri-apps/plugin-store";
 import { tauriStorage } from "@/lib/stores/tauri-storage-adapter.helpers";
@@ -19,18 +19,16 @@ const INITIAL_STATE: Pick<State, "workingMode"> = {
 
 const useWorkingModeStore = create<State>()(
     devtools(
-        persist(
-            set => ({
-                ...INITIAL_STATE,
-                setWorkingMode: mode => set(() => ({ workingMode: mode })),
-                resetWorkingMode: () =>
-                    set(() => ({ workingMode: INITIAL_STATE.workingMode })),
-            }),
-            {
-                name: STORE_NAME,
-                storage: createJSONStorage(() => tauriStorage(STORE_FILE)),
-            }
-        )
+        set => ({
+            ...INITIAL_STATE,
+            setWorkingMode: mode => set(() => ({ workingMode: mode })),
+            resetWorkingMode: () =>
+                set(() => ({ workingMode: INITIAL_STATE.workingMode })),
+        }),
+        {
+            name: STORE_NAME,
+            storage: createJSONStorage(() => tauriStorage(STORE_FILE)),
+        }
     )
 );
 

--- a/src/lib/stores/WorkingMode/WorkingMode.store.ts
+++ b/src/lib/stores/WorkingMode/WorkingMode.store.ts
@@ -1,6 +1,11 @@
 import { create } from "zustand";
-import { devtools, persist } from "zustand/middleware";
+import { createJSONStorage, devtools, persist } from "zustand/middleware";
 import { WORKING_MODE } from "@/views/selectMode";
+import { createStore, Store } from "@tauri-apps/plugin-store";
+import { tauriStorage } from "@/lib/stores/tauri-storage-adapter.helpers";
+
+const STORE_NAME = "working-mode";
+const STORE_FILE: Store = await createStore(`${STORE_NAME}.dat`);
 
 type State = {
     workingMode: WORKING_MODE | null;
@@ -22,7 +27,8 @@ const useWorkingModeStore = create<State>()(
                     set(() => ({ workingMode: INITIAL_STATE.workingMode })),
             }),
             {
-                name: "working-mode",
+                name: STORE_NAME,
+                storage: createJSONStorage(() => tauriStorage(STORE_FILE)),
             }
         )
     )

--- a/src/lib/stores/WorkingMode/WorkingMode.store.ts
+++ b/src/lib/stores/WorkingMode/WorkingMode.store.ts
@@ -4,7 +4,7 @@ import { WORKING_MODE } from "@/views/selectMode";
 
 type State = {
     workingMode: WORKING_MODE | null;
-    setWorkingMode: (mode: WORKING_MODE | null) => void;
+    setWorkingMode: (mode: WORKING_MODE) => void;
     resetWorkingMode: () => void;
 };
 

--- a/src/lib/stores/WorkingMode/WorkingMode.ts
+++ b/src/lib/stores/WorkingMode/WorkingMode.ts
@@ -12,7 +12,7 @@ class StoreClass {
 
     readonly actions = {
         setWorkingMode: (mode: State["workingMode"]) => {
-            this.state.setWorkingMode(mode);
+            this.state.setWorkingMode(mode!);
         },
         resetWorkingMode: () => {
             this.state.resetWorkingMode();

--- a/src/lib/utils/viewport/loadMarkingsData.ts
+++ b/src/lib/utils/viewport/loadMarkingsData.ts
@@ -23,8 +23,8 @@ import {
     defaultSize,
     defaultTextColor,
     MarkingCharacteristic,
-    WORKING_MODE,
 } from "@/lib/markings/MarkingCharacteristic";
+import { WorkingModeStore } from "@/lib/stores/WorkingMode";
 import { ExportObject } from "./saveMarkingsDataWithDialog";
 
 export function validateFileData(_data: unknown): _data is ExportObject {
@@ -74,8 +74,10 @@ export async function loadMarkingsData(filePath: string, canvasId: CANVAS_ID) {
         if (!confirmed) return;
     }
 
-    // TODO Get current working mode
-    if (fileContentJson.metadata.workingMode !== WORKING_MODE.FINGERPRINT) {
+    if (
+        fileContentJson.metadata.workingMode !==
+        WorkingModeStore.state.workingMode
+    ) {
         showErrorDialog(
             t(
                 "The markings data was created with a different working mode ({{mode}}). Change the working mode to ({{mode}}) to load the data.",

--- a/src/lib/utils/viewport/saveMarkingsDataWithDialog.ts
+++ b/src/lib/utils/viewport/saveMarkingsDataWithDialog.ts
@@ -20,6 +20,7 @@ import { RayMarking } from "@/lib/markings/RayMarking";
 import { LineSegmentMarking } from "@/lib/markings/LineSegmentMarking";
 import { MarkingCharacteristicsStore } from "@/lib/stores/MarkingCharacteristics/MarkingCharacteristics";
 import { WorkingModeStore } from "@/lib/stores/WorkingMode";
+import { WORKING_MODE } from "@/views/selectMode";
 
 type ImageInfo = {
     name: string | null;

--- a/src/lib/utils/viewport/saveMarkingsDataWithDialog.ts
+++ b/src/lib/utils/viewport/saveMarkingsDataWithDialog.ts
@@ -38,7 +38,7 @@ export type ExportObject = {
         software: SoftwareInfo;
         image: ImageInfo | null;
         compared_image: ImageInfo | null;
-        workingMode: WORKING_MODE | null;
+        workingMode: WORKING_MODE;
     };
     data: {
         markings: {
@@ -93,7 +93,7 @@ async function getData(
             },
             image: getImageData(picture),
             compared_image: getImageData(oppositePicture),
-            workingMode,
+            workingMode: workingMode!,
         },
         data: {
             markings,

--- a/src/lib/utils/viewport/saveMarkingsDataWithDialog.ts
+++ b/src/lib/utils/viewport/saveMarkingsDataWithDialog.ts
@@ -15,7 +15,8 @@ import { basename } from "@tauri-apps/api/path";
 import { MarkingBase } from "@/lib/markings/MarkingBase";
 import { RayMarking } from "@/lib/markings/RayMarking";
 import { LineSegmentMarking } from "@/lib/markings/LineSegmentMarking";
-import { WORKING_MODE } from "@/lib/markings/MarkingCharacteristic";
+import { WorkingModeStore } from "@/lib/stores/WorkingMode";
+import { WORKING_MODE } from "@/views/selectMode";
 
 type ImageInfo = {
     name: string | null;
@@ -37,7 +38,7 @@ export type ExportObject = {
         software: SoftwareInfo;
         image: ImageInfo | null;
         compared_image: ImageInfo | null;
-        workingMode: WORKING_MODE;
+        workingMode: WORKING_MODE | null;
     };
     data: {
         markings: {
@@ -81,6 +82,9 @@ async function getData(
     const id = viewport.name as CanvasMetadata["id"] | null;
     if (id === null) throw new Error("Canvas ID not found");
 
+    const { workingMode } = WorkingModeStore.state;
+    const { markings } = MarkingsStore(id).state;
+
     const exportObject: ExportObject = {
         metadata: {
             software: {
@@ -89,11 +93,10 @@ async function getData(
             },
             image: getImageData(picture),
             compared_image: getImageData(oppositePicture),
-            // TODO Get current working mode
-            workingMode: WORKING_MODE.FINGERPRINT,
+            workingMode,
         },
         data: {
-            markings: MarkingsStore(id).state.markings,
+            markings,
         },
     };
 


### PR DESCRIPTION
# Closes #31 :>

- when exporting characteristics, only those from the WORKING_MODE are exported
- when importing characteristics, there is a check if WORKING_MODE exists in the application. (will be changed soon)
- characteristics are now only available per working mode - if you create some for fingerprints, they won't be available when marking ears


## We should release `0.4.0` after merging this branch into master, as this pull request completes the last task for the `0.4.0` milestone.