### PR TITLE
Fixed locked zoom scale drift

### DIFF
--- a/src/components/pixi/viewport/event-handlers/opposite-moved.event.ts
+++ b/src/components/pixi/viewport/event-handlers/opposite-moved.event.ts
@@ -3,7 +3,6 @@ import {
     CachedViewportPosition,
     CachedViewportZoom,
 } from "@/lib/stores/CachedViewport";
-import { round } from "@/lib/utils/math/round";
 import {
     FitEvent,
     fitHeight,
@@ -31,8 +30,7 @@ export const handleOppositeMove = (
         case "wheel": {
             const { value } = delta as CachedViewportZoom;
 
-            const oldScale = viewport.scaled;
-            const newScale = round(oldScale * value, 3);
+            const newScale = viewport.scaled * value;
 
             if (newScale !== store.state.oppositeScaled) {
                 viewport.setZoom(newScale, true);

--- a/src/components/pixi/viewport/viewport.tsx
+++ b/src/components/pixi/viewport/viewport.tsx
@@ -36,17 +36,12 @@ export const Viewport = forwardRef<PixiViewport, ViewportProps>(
                     allowPreserveDragOutside: true,
                 }}
                 sideEffects={viewport => {
-                    viewport
-                        .wheel({
-                            percent: 0,
-                            interrupt: true,
-                            wheelZoom: true,
-                            center: viewport.center,
-                        })
-                        .clampZoom({
-                            minScale: 1 / 4,
-                            maxScale: 100,
-                        });
+                    viewport.wheel({
+                        percent: 0,
+                        interrupt: true,
+                        wheelZoom: true,
+                        center: viewport.center,
+                    });
 
                     const handlerParams: ViewportHandlerParams = {
                         viewport,


### PR DESCRIPTION
Closes #67 

there's still a small bug - when you zoom in to a certain level, you can't zoom in further even though there's no clamp and you also can't zoom out from that point - only option is to click one of fit to viewport buttons