### PR TITLE
feat: retire labels to cosmetic only and fix id consistency issues

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,6 @@ import { GlobalToolbar } from "@/components/toolbar/toolbar";
 import { CUSTOM_GLOBAL_EVENTS } from "@/lib/utils/const";
 import { MarkingsStore } from "@/lib/stores/Markings";
 import { CANVAS_ID } from "@/components/pixi/canvas/hooks/useCanvasContext";
-import { GlobalStateStore } from "@/lib/stores/GlobalState";
 
 const enum TABS {
     HOMEPAGE = "homepage",
@@ -28,7 +27,6 @@ export default function Home() {
             );
             MarkingsStore(CANVAS_ID.LEFT).actions.labelGenerator.reset();
             MarkingsStore(CANVAS_ID.RIGHT).actions.labelGenerator.reset();
-            GlobalStateStore.actions.lastAddedMarking.setLastAddedMarking(null);
         };
 
         document.addEventListener(CUSTOM_GLOBAL_EVENTS.CLEANUP, performCleanup);

--- a/src/components/information-tabs/markings-info/markings-info-table-columns.tsx
+++ b/src/components/information-tabs/markings-info/markings-info-table-columns.tsx
@@ -46,6 +46,31 @@ export const useColumns = (
 ): ColumnDef<EmptyableMarking, Element>[] => {
     const { t } = useTranslation();
 
+    const handleRemoveClick = (marking: MarkingClass) => {
+        MarkingsStore(id).actions.markings.removeOneByLabel(marking.label);
+    };
+
+    const handleMergeClick = (marking: MarkingClass) => {
+        const current = {
+            canvasId: id,
+            label: marking.label,
+        };
+        const pendingSel = GlobalStateStore.state.pendingMerge;
+
+        if (!pendingSel) {
+            GlobalStateStore.actions.merge.setPending(current);
+        } else if (pendingSel.canvasId !== id) {
+            MarkingsStore(pendingSel.canvasId).actions.markings.mergePair(
+                pendingSel.label,
+                id,
+                marking.label
+            );
+            GlobalStateStore.actions.merge.setPending(null);
+        } else {
+            GlobalStateStore.actions.merge.setPending(current);
+        }
+    };
+
     return useMemo(
         () =>
             [
@@ -85,14 +110,11 @@ export const useColumns = (
                                             size="sm-icon"
                                             variant="outline"
                                             pressed={false}
-                                            onClickCapture={() => {
-                                                MarkingsStore(
-                                                    id
-                                                ).actions.markings.removeOneByLabel(
-                                                    (marking as MarkingClass)
-                                                        .label
-                                                );
-                                            }}
+                                            onClickCapture={() =>
+                                                handleRemoveClick(
+                                                    marking as MarkingClass
+                                                )
+                                            }
                                         >
                                             <Trash2
                                                 size={ICON.SIZE}
@@ -105,41 +127,11 @@ export const useColumns = (
                                             variant="outline"
                                             pressed={!!isPendingHere}
                                             disabled={hasCounterpart}
-                                            onClickCapture={() => {
-                                                const current = {
-                                                    canvasId: id,
-                                                    label: (
-                                                        marking as MarkingClass
-                                                    ).label,
-                                                };
-                                                const pendingSel =
-                                                    GlobalStateStore.state
-                                                        .pendingMerge;
-                                                if (!pendingSel) {
-                                                    GlobalStateStore.actions.merge.setPending(
-                                                        current
-                                                    );
-                                                } else if (
-                                                    pendingSel.canvasId !== id
-                                                ) {
-                                                    MarkingsStore(
-                                                        pendingSel.canvasId
-                                                    ).actions.markings.mergePair(
-                                                        pendingSel.label,
-                                                        id,
-                                                        (
-                                                            marking as MarkingClass
-                                                        ).label
-                                                    );
-                                                    GlobalStateStore.actions.merge.setPending(
-                                                        null
-                                                    );
-                                                } else {
-                                                    GlobalStateStore.actions.merge.setPending(
-                                                        current
-                                                    );
-                                                }
-                                            }}
+                                            onClickCapture={() =>
+                                                handleMergeClick(
+                                                    marking as MarkingClass
+                                                )
+                                            }
                                         >
                                             <Link2
                                                 size={ICON.SIZE}

--- a/src/components/information-tabs/markings-info/markings-info-table-columns.tsx
+++ b/src/components/information-tabs/markings-info/markings-info-table-columns.tsx
@@ -1,6 +1,6 @@
 import { CellContext, ColumnDef } from "@tanstack/react-table";
 import { ICON } from "@/lib/utils/const";
-import { Trash2 } from "lucide-react";
+import { Trash2, Link2 } from "lucide-react";
 import { Toggle } from "@/components/ui/toggle";
 import { CanvasMetadata } from "@/components/pixi/canvas/hooks/useCanvasContext";
 import { MarkingsStore } from "@/lib/stores/Markings";
@@ -8,7 +8,9 @@ import { MarkingClass } from "@/lib/markings/MarkingClass";
 import { useTranslation } from "react-i18next";
 import { useMemo } from "react";
 import { MarkingTypesStore } from "@/lib/stores/MarkingTypes/MarkingTypes";
-
+import { getOppositeCanvasId } from "@/components/pixi/canvas/utils/get-opposite-canvas-id";
+import { GlobalStateStore } from "@/lib/stores/GlobalState";
+/* eslint-disable sonarjs/no-duplicated-branches */
 export type EmptyMarking = {
     label: MarkingClass["label"];
 };
@@ -17,7 +19,7 @@ type EmptyableCellContext = CellContext<EmptyableMarking, unknown>;
 type DataCellContext = CellContext<MarkingClass, unknown>;
 
 export function isMarkingBase(cell: EmptyableMarking): cell is MarkingClass {
-    return "id" in cell;
+    return "ids" in cell;
 }
 
 const formatCell = <T,>(
@@ -51,33 +53,100 @@ export const useColumns = (
                     id: "actions",
                     cell: ({ row }) => {
                         const marking = row.original;
+                        const oppositeId = getOppositeCanvasId(id);
+                        const oppositeMarkings =
+                            MarkingsStore(oppositeId).state.markings;
+                        const hasCounterpart =
+                            isMarkingBase(marking) &&
+                            oppositeMarkings.some(om =>
+                                om.ids.some(idv =>
+                                    (marking as MarkingClass).ids.includes(idv)
+                                )
+                            );
+                        const pending = GlobalStateStore.state.pendingMerge;
+                        const isPendingHere =
+                            isMarkingBase(marking) &&
+                            pending &&
+                            pending.canvasId === id &&
+                            pending.label === marking.label;
+                        /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
                         return (
-                            // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+                            /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
                             <div
                                 className="flex gap-0.5"
                                 onClick={e => {
                                     e.stopPropagation();
                                 }}
                             >
-                                {isMarkingBase(marking) && marking.id && (
-                                    <Toggle
-                                        title="Remove"
-                                        size="sm-icon"
-                                        variant="outline"
-                                        pressed={false}
-                                        onClickCapture={() => {
-                                            MarkingsStore(
-                                                id
-                                            ).actions.markings.removeOneByLabel(
-                                                marking.label
-                                            );
-                                        }}
-                                    >
-                                        <Trash2
-                                            size={ICON.SIZE}
-                                            strokeWidth={ICON.STROKE_WIDTH}
-                                        />
-                                    </Toggle>
+                                {isMarkingBase(marking) && (
+                                    <>
+                                        <Toggle
+                                            title="Remove"
+                                            size="sm-icon"
+                                            variant="outline"
+                                            pressed={false}
+                                            onClickCapture={() => {
+                                                MarkingsStore(
+                                                    id
+                                                ).actions.markings.removeOneByLabel(
+                                                    (marking as MarkingClass)
+                                                        .label
+                                                );
+                                            }}
+                                        >
+                                            <Trash2
+                                                size={ICON.SIZE}
+                                                strokeWidth={ICON.STROKE_WIDTH}
+                                            />
+                                        </Toggle>
+                                        <Toggle
+                                            title="Merge"
+                                            size="sm-icon"
+                                            variant="outline"
+                                            pressed={!!isPendingHere}
+                                            disabled={hasCounterpart}
+                                            onClickCapture={() => {
+                                                const current = {
+                                                    canvasId: id,
+                                                    label: (
+                                                        marking as MarkingClass
+                                                    ).label,
+                                                };
+                                                const pendingSel =
+                                                    GlobalStateStore.state
+                                                        .pendingMerge;
+                                                if (!pendingSel) {
+                                                    GlobalStateStore.actions.merge.setPending(
+                                                        current
+                                                    );
+                                                } else if (
+                                                    pendingSel.canvasId !== id
+                                                ) {
+                                                    MarkingsStore(
+                                                        pendingSel.canvasId
+                                                    ).actions.markings.mergePair(
+                                                        pendingSel.label,
+                                                        id,
+                                                        (
+                                                            marking as MarkingClass
+                                                        ).label
+                                                    );
+                                                    GlobalStateStore.actions.merge.setPending(
+                                                        null
+                                                    );
+                                                } else {
+                                                    GlobalStateStore.actions.merge.setPending(
+                                                        current
+                                                    );
+                                                }
+                                            }}
+                                        >
+                                            <Link2
+                                                size={ICON.SIZE}
+                                                strokeWidth={ICON.STROKE_WIDTH}
+                                            />
+                                        </Toggle>
+                                    </>
                                 )}
                             </div>
                         );
@@ -95,9 +164,7 @@ export const useColumns = (
                 },
                 {
                     accessorKey: "type",
-                    header: t("MarkingType.Keys.name", {
-                        ns: "object",
-                    }),
+                    header: t("MarkingType.Keys.name", { ns: "object" }),
                     cell: info =>
                         formatCell(info, ({ row }) => {
                             const marking = row.original.typeId;

--- a/src/components/information-tabs/markings-info/markings-info-table.tsx
+++ b/src/components/information-tabs/markings-info/markings-info-table.tsx
@@ -84,7 +84,6 @@ const TableRowComponent = <TData,>(rows: Row<TData>[], canvasId: CANVAS_ID) => {
                 data-state={isSelected && "selected"}
                 onClickCapture={() => {
                     if (selectedMarkingLabel === marking.label) {
-                        // odznacz
                         MarkingsStore(
                             canvasId
                         ).actions.selectedMarkingLabel.setSelectedMarkingLabel(

--- a/src/components/information-tabs/markings-info/markings-info-table.tsx
+++ b/src/components/information-tabs/markings-info/markings-info-table.tsx
@@ -29,7 +29,6 @@ import { CANVAS_ID } from "@/components/pixi/canvas/hooks/useCanvasContext";
 import { CUSTOM_GLOBAL_EVENTS } from "@/lib/utils/const";
 import { triggerPostMoveFlash } from "@atlaskit/pragmatic-drag-and-drop-flourish/trigger-post-move-flash";
 import { sleep } from "@/lib/utils/misc/sleep";
-import { GlobalStateStore } from "@/lib/stores/GlobalState";
 import { EmptyableMarking } from "./markings-info-table-columns";
 
 // Original Table is wrapped with a <div> (see https://ui.shadcn.com/docs/components/table#radix-:r24:-content-manual),
@@ -46,8 +45,6 @@ const TableComponent = forwardRef<
 ));
 TableComponent.displayName = "TableComponent";
 
-let hasFlashed = false;
-
 const TableRowComponent = <TData,>(rows: Row<TData>[], canvasId: CANVAS_ID) => {
     return function useTableRow(props: HTMLAttributes<HTMLTableRowElement>) {
         // @ts-expect-error data-index is a valid attribute
@@ -62,7 +59,6 @@ const TableRowComponent = <TData,>(rows: Row<TData>[], canvasId: CANVAS_ID) => {
                     return;
                 }
                 triggerPostMoveFlash(element);
-                hasFlashed = true;
             });
         }, []);
 
@@ -74,13 +70,7 @@ const TableRowComponent = <TData,>(rows: Row<TData>[], canvasId: CANVAS_ID) => {
 
         const isSelected = selectedMarkingLabel === marking.label;
 
-        const { lastAddedMarking } = GlobalStateStore.state;
-        const isLastAdded =
-            lastAddedMarking &&
-            lastAddedMarking.canvasId === canvasId &&
-            lastAddedMarking.marking.label === marking.label;
-
-        if (isLastAdded && !hasFlashed) {
+        if (isSelected) {
             runAnimation();
         }
 
@@ -202,9 +192,6 @@ export const MarkingsInfoTable = function <TData, TValue>({
     }, [selectedMarking, data, rows]);
 
     useEffect(() => {
-        if (data.length > prevDataLength) {
-            hasFlashed = false;
-        }
         prevDataLength = data.length;
     }, [data.length]);
 

--- a/src/components/information-tabs/markings-info/markings-info.tsx
+++ b/src/components/information-tabs/markings-info/markings-info.tsx
@@ -11,8 +11,6 @@ import { MarkingsInfoTable } from "./markings-info-table";
 const fillMissingLabels = (
     markings: EmptyableMarking[]
 ): EmptyableMarking[] => {
-    // Nie wypełniaj brakujących etykiet placeholderami.
-    // Wiersze wyświetlamy tylko dla labeli istniejących po którejkolwiek stronie.
     return markings;
 };
 
@@ -66,7 +64,7 @@ export function MarkingsInfo({ tableHeight }: { tableHeight: number }) {
         ]
             .sort((a, b) => a.label - b.label)
             .map(m =>
-                // jeśli którykolwiek z ids występuje po tej stronie – pokaż pełny obiekt, inaczej placeholder
+                // if any id exists on this side - show full object, otherwise placeholder
                 m.ids.some(id => thisIds.has(id)) ? m : { label: m.label }
             ) as EmptyableMarking[];
 

--- a/src/components/information-tabs/markings-info/markings-info.tsx
+++ b/src/components/information-tabs/markings-info/markings-info.tsx
@@ -1,8 +1,5 @@
 import { MarkingsStore } from "@/lib/stores/Markings";
-import {
-    CANVAS_ID,
-    useCanvasContext,
-} from "@/components/pixi/canvas/hooks/useCanvasContext";
+import { useCanvasContext } from "@/components/pixi/canvas/hooks/useCanvasContext";
 import { useEffect, useMemo } from "react";
 import { getOppositeCanvasId } from "@/components/pixi/canvas/utils/get-opposite-canvas-id";
 import { IS_DEV_ENVIRONMENT } from "@/lib/utils/const";
@@ -12,19 +9,11 @@ import { EmptyableMarking, useColumns } from "./markings-info-table-columns";
 import { MarkingsInfoTable } from "./markings-info-table";
 
 const fillMissingLabels = (
-    canvasId: CANVAS_ID,
     markings: EmptyableMarking[]
 ): EmptyableMarking[] => {
-    const maxLabel =
-        MarkingsStore(canvasId).actions.labelGenerator.getMaxLabel();
-    if (!maxLabel || maxLabel <= 1) return markings;
-
-    const usedLabels = new Set(markings.map(m => m.label));
-    return Array.from({ length: maxLabel }, (_, i) =>
-        usedLabels.has(i + 1)
-            ? markings.find(m => m.label === i + 1)!
-            : { label: i + 1 }
-    );
+    // Nie wypełniaj brakujących etykiet placeholderami.
+    // Wiersze wyświetlamy tylko dla labeli istniejących po którejkolwiek stronie.
+    return markings;
 };
 
 export function MarkingsInfo({ tableHeight }: { tableHeight: number }) {
@@ -39,7 +28,6 @@ export function MarkingsInfo({ tableHeight }: { tableHeight: number }) {
             hash: state.markingsHash,
         }),
         (oldState, newState) => {
-            // re-rendering tylko wtedy, gdy zmieni się hash stanu
             return oldState.hash === newState.hash;
         }
     );
@@ -52,13 +40,11 @@ export function MarkingsInfo({ tableHeight }: { tableHeight: number }) {
             hash: state.markingsHash,
         }),
         (oldState, newState) => {
-            // re-rendering tylko wtedy, gdy zmieni się hash stanu
             return oldState.hash === newState.hash;
         }
     );
 
     useEffect(() => {
-        // sprawdzanie, czy znaczniki są unikalne
         if (IS_DEV_ENVIRONMENT) {
             const markingLabels = storeMarkings.map(m => m.label);
 
@@ -72,7 +58,7 @@ export function MarkingsInfo({ tableHeight }: { tableHeight: number }) {
     const columns = useColumns(id);
 
     const markings = useMemo(() => {
-        const thisIds = storeMarkings.map(m => m.id);
+        const thisIds = new Set(storeMarkings.flatMap(m => m.ids));
         const thisLabels = storeMarkings.map(m => m.label);
         const combinedMarkings = [
             ...storeMarkings,
@@ -80,10 +66,11 @@ export function MarkingsInfo({ tableHeight }: { tableHeight: number }) {
         ]
             .sort((a, b) => a.label - b.label)
             .map(m =>
-                thisIds.includes(m.id) ? m : { label: m.label }
+                // jeśli którykolwiek z ids występuje po tej stronie – pokaż pełny obiekt, inaczej placeholder
+                m.ids.some(id => thisIds.has(id)) ? m : { label: m.label }
             ) as EmptyableMarking[];
 
-        return fillMissingLabels(id, combinedMarkings);
+        return fillMissingLabels(combinedMarkings);
     }, [storeMarkings, storeOppositeMarkings, id]);
 
     return (

--- a/src/components/menu/mode-menu.tsx
+++ b/src/components/menu/mode-menu.tsx
@@ -8,7 +8,6 @@ import {
 import { WORKING_MODE } from "@/views/selectMode";
 import { MarkingsStore } from "@/lib/stores/Markings";
 import { CANVAS_ID } from "@/components/pixi/canvas/hooks/useCanvasContext";
-import { GlobalStateStore } from "@/lib/stores/GlobalState";
 import { WorkingModeStore } from "@/lib/stores/WorkingMode";
 import { useTranslation } from "react-i18next";
 import { confirm } from "@tauri-apps/plugin-dialog";
@@ -47,26 +46,29 @@ export function ModeMenu() {
         }
 
         // Destroy current image sprites
-        viewportLeft?.children
-            .find(x => x instanceof Sprite)
-            ?.destroy({
-                children: true,
-                texture: true,
-                baseTexture: true,
-            });
-        viewportRight?.children
-            .find(x => x instanceof Sprite)
-            ?.destroy({
-                children: true,
-                texture: true,
-                baseTexture: true,
-            });
+        (
+            viewportLeft?.children.find(x => x instanceof Sprite) as
+                | Sprite
+                | undefined
+        )?.destroy({
+            children: true,
+            texture: true,
+            baseTexture: true,
+        });
+        (
+            viewportRight?.children.find(x => x instanceof Sprite) as
+                | Sprite
+                | undefined
+        )?.destroy({
+            children: true,
+            texture: true,
+            baseTexture: true,
+        });
 
         MarkingsStore(CANVAS_ID.LEFT).actions.markings.reset();
         MarkingsStore(CANVAS_ID.RIGHT).actions.markings.reset();
         MarkingsStore(CANVAS_ID.LEFT).actions.labelGenerator.reset();
         MarkingsStore(CANVAS_ID.RIGHT).actions.labelGenerator.reset();
-        GlobalStateStore.actions.lastAddedMarking.setLastAddedMarking(null);
 
         setWorkingMode(mode);
     };

--- a/src/components/pixi/viewport/marking-handlers/boundingBoxMarkingHandler.ts
+++ b/src/components/pixi/viewport/marking-handlers/boundingBoxMarkingHandler.ts
@@ -17,9 +17,10 @@ export class BoundingBoxMarkingHandler extends MarkingHandler {
 
     private initMarking(e: FederatedPointerEvent) {
         const { viewport, markingsStore } = this.plugin.handlerParams;
+        const label = markingsStore.actions.labelGenerator.getLabel();
         markingsStore.actions.temporaryMarking.setTemporaryMarking(
             new BoundingBoxMarking(
-                markingsStore.actions.labelGenerator.getLabel(),
+                label,
                 getNormalizedMousePosition(e, viewport),
                 this.typeId,
                 getNormalizedMousePosition(e, viewport)

--- a/src/components/pixi/viewport/marking-handlers/lineSegmentMarkingHandler.ts
+++ b/src/components/pixi/viewport/marking-handlers/lineSegmentMarkingHandler.ts
@@ -19,9 +19,10 @@ export class LineSegmentMarkingHandler extends MarkingHandler {
 
     private initFirstStage(e: FederatedPointerEvent) {
         const { viewport, markingsStore } = this.plugin.handlerParams;
+        const label = markingsStore.actions.labelGenerator.getLabel();
         markingsStore.actions.temporaryMarking.setTemporaryMarking(
             new LineSegmentMarking(
-                markingsStore.actions.labelGenerator.getLabel(),
+                label,
                 getNormalizedMousePosition(e, viewport),
                 this.typeId,
                 getNormalizedMousePosition(e, viewport)

--- a/src/components/pixi/viewport/marking-handlers/pointMarkingHandler.ts
+++ b/src/components/pixi/viewport/marking-handlers/pointMarkingHandler.ts
@@ -17,9 +17,10 @@ export class PointMarkingHandler extends MarkingHandler {
 
     private initMarking(e: FederatedPointerEvent) {
         const { viewport, markingsStore } = this.plugin.handlerParams;
+        const label = markingsStore.actions.labelGenerator.getLabel();
         markingsStore.actions.temporaryMarking.setTemporaryMarking(
             new PointMarking(
-                markingsStore.actions.labelGenerator.getLabel(),
+                label,
                 getNormalizedMousePosition(e, viewport),
                 this.typeId
             )

--- a/src/components/pixi/viewport/marking-handlers/rayMarkingHandler.ts
+++ b/src/components/pixi/viewport/marking-handlers/rayMarkingHandler.ts
@@ -20,9 +20,10 @@ export class RayMarkingHandler extends MarkingHandler {
 
     private initFirstStage(e: FederatedPointerEvent) {
         const { viewport, markingsStore } = this.plugin.handlerParams;
+        const label = markingsStore.actions.labelGenerator.getLabel();
         markingsStore.actions.temporaryMarking.setTemporaryMarking(
             new RayMarking(
-                markingsStore.actions.labelGenerator.getLabel(),
+                label,
                 getNormalizedMousePosition(e, viewport),
                 this.typeId,
                 0

--- a/src/components/pixi/viewport/plugins/markingModePlugin.ts
+++ b/src/components/pixi/viewport/plugins/markingModePlugin.ts
@@ -6,7 +6,7 @@ import {
     DashboardToolbarStore,
 } from "@/lib/stores/DashboardToolbar";
 import { MarkingTypesStore } from "@/lib/stores/MarkingTypes/MarkingTypes";
-import { CUSTOM_GLOBAL_EVENTS, IS_DEV_ENVIRONMENT } from "@/lib/utils/const";
+import { CUSTOM_GLOBAL_EVENTS } from "@/lib/utils/const";
 import {
     MarkingHandler,
     PointMarkingHandler,
@@ -35,7 +35,6 @@ export class MarkingModePlugin extends Plugin {
         this.handlerParams = handlerParams;
 
         this.viewport.on("mousedown", this.handleMouseDown);
-        this.viewport.on("rightdown", this.handleRightDown);
         window.addEventListener("keydown", this.handleKeyDown);
         window.addEventListener("keyup", this.handleKeyUp);
     }
@@ -69,12 +68,6 @@ export class MarkingModePlugin extends Plugin {
     private handleMouseDown = (e: FederatedPointerEvent): void => {
         if (this.shouldHandleMarking() && e.button === 0) {
             this.startMarking(e);
-        }
-    };
-
-    private handleRightDown = (e: FederatedPointerEvent): void => {
-        if (this.shouldHandleMarking() && IS_DEV_ENVIRONMENT) {
-            console.log(e);
         }
     };
 

--- a/src/lib/locales/en/object.ts
+++ b/src/lib/locales/en/object.ts
@@ -4,7 +4,7 @@ const d: Dictionary = {
     Marking: {
         Name: "Marking",
         Keys: {
-            id: "ID",
+            ids: "IDs",
             label: "Label",
             angleRad: "Angle",
             origin: "Origin",
@@ -19,6 +19,12 @@ const d: Dictionary = {
                 },
             },
             typeId: "Type ID",
+        },
+        Actions: {
+            merge: {
+                enabled: "Merge markings",
+                disabled: "Cannot merge - matching IDs found",
+            },
         },
     },
     MarkingType: {

--- a/src/lib/locales/pl/object.ts
+++ b/src/lib/locales/pl/object.ts
@@ -4,7 +4,7 @@ const d: Dictionary = {
     Marking: {
         Name: "Adnotacja",
         Keys: {
-            id: "ID",
+            ids: "ID-y",
             label: "Znacznik",
             angleRad: "Kąt",
             origin: "Źródło",
@@ -19,6 +19,12 @@ const d: Dictionary = {
                 },
             },
             typeId: "ID typu",
+        },
+        Actions: {
+            merge: {
+                enabled: "Połącz adnotacje",
+                disabled: "Nie można połączyć - znaleziono pasujące ID",
+            },
         },
     },
     MarkingType: {

--- a/src/lib/locales/translation.ts
+++ b/src/lib/locales/translation.ts
@@ -46,6 +46,12 @@ export type i18nObject = {
                 Keys: Recordify<MARKING_CLASS>;
             };
         };
+        Actions: {
+            merge: {
+                enabled: string;
+                disabled: string;
+            };
+        };
     };
     MarkingType: {
         Name: string;

--- a/src/lib/markings/BoundingBoxMarking.ts
+++ b/src/lib/markings/BoundingBoxMarking.ts
@@ -9,9 +9,10 @@ export class BoundingBoxMarking extends MarkingClass {
         label: MarkingClass["label"],
         origin: MarkingClass["origin"],
         typeId: MarkingClass["typeId"],
-        public endpoint: Point
+        public endpoint: Point,
+        ids?: string[]
     ) {
-        super(label, origin, typeId);
+        super(label, origin, typeId, ids);
     }
 
     public calculateEndpointViewportPosition(

--- a/src/lib/markings/LineSegmentMarking.ts
+++ b/src/lib/markings/LineSegmentMarking.ts
@@ -9,9 +9,10 @@ export class LineSegmentMarking extends MarkingClass {
         label: MarkingClass["label"],
         origin: MarkingClass["origin"],
         typeId: MarkingClass["typeId"],
-        public endpoint: Point
+        public endpoint: Point,
+        ids?: string[]
     ) {
-        super(label, origin, typeId);
+        super(label, origin, typeId, ids);
     }
 
     public calculateEndpointViewportPosition(

--- a/src/lib/markings/MarkingClass.ts
+++ b/src/lib/markings/MarkingClass.ts
@@ -8,10 +8,8 @@ export abstract class MarkingClass {
 
     public abstract readonly markingClass: MARKING_CLASS;
 
-    // Stabilne ID-y (mogą być scalone z wielu znaczników)
     public ids: string[];
 
-    // label: ephemeral – przydzielany dynamicznie po imporcie, NIE jest eksportowany
     public constructor(
         public label: number,
         public origin: Point,

--- a/src/lib/markings/MarkingClass.ts
+++ b/src/lib/markings/MarkingClass.ts
@@ -8,13 +8,20 @@ export abstract class MarkingClass {
 
     public abstract readonly markingClass: MARKING_CLASS;
 
-    public readonly id: string = crypto.randomUUID();
+    // Stabilne ID-y (mogą być scalone z wielu znaczników)
+    public ids: string[];
 
-    protected constructor(
+    // label: ephemeral – przydzielany dynamicznie po imporcie, NIE jest eksportowany
+    public constructor(
         public label: number,
         public origin: Point,
-        public typeId: MarkingType["id"]
+        public typeId: MarkingType["id"],
+        ids?: string[]
     ) {
+        this.ids =
+            ids && ids.length > 0
+                ? Array.from(new Set(ids))
+                : [crypto.randomUUID()];
         this.label = label;
         this.origin = origin;
         this.typeId = typeId;

--- a/src/lib/markings/PointMarking.ts
+++ b/src/lib/markings/PointMarking.ts
@@ -9,8 +9,9 @@ export class PointMarking extends MarkingClass {
     constructor(
         label: MarkingClass["label"],
         origin: MarkingClass["origin"],
-        typeId: MarkingType["id"]
+        typeId: MarkingType["id"],
+        ids?: string[]
     ) {
-        super(label, origin, typeId);
+        super(label, origin, typeId, ids);
     }
 }

--- a/src/lib/markings/RayMarking.ts
+++ b/src/lib/markings/RayMarking.ts
@@ -8,9 +8,10 @@ export class RayMarking extends MarkingClass {
         label: MarkingClass["label"],
         origin: MarkingClass["origin"],
         typeId: MarkingClass["typeId"],
-        public angleRad: number
+        public angleRad: number,
+        ids?: string[]
     ) {
-        super(label, origin, typeId);
+        super(label, origin, typeId, ids);
         this.angleRad = angleRad;
     }
 }

--- a/src/lib/stores/GlobalState/GlobalState.store.ts
+++ b/src/lib/stores/GlobalState/GlobalState.store.ts
@@ -2,20 +2,20 @@ import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { CanvasMetadata } from "@/components/pixi/canvas/hooks/useCanvasContext";
 // eslint-disable-next-line import/no-cycle
-import { MarkingClass } from "@/lib/markings/MarkingClass";
 import { Immer, produceCallback } from "../immer.helpers";
 
-type LastAddedMarkerState = {
-    marking: MarkingClass;
+// Nowy typ: wybór do scalenia
+export type PendingMerge = {
     canvasId: CanvasMetadata["id"];
+    label: number;
 } | null;
 
 type State = {
-    lastAddedMarking: LastAddedMarkerState;
+    pendingMerge: PendingMerge;
 };
 
 const INITIAL_STATE: State = {
-    lastAddedMarking: null,
+    pendingMerge: null,
 };
 
 const useStore = create<Immer<State>>()(

--- a/src/lib/stores/GlobalState/GlobalState.store.ts
+++ b/src/lib/stores/GlobalState/GlobalState.store.ts
@@ -4,7 +4,6 @@ import { CanvasMetadata } from "@/components/pixi/canvas/hooks/useCanvasContext"
 // eslint-disable-next-line import/no-cycle
 import { Immer, produceCallback } from "../immer.helpers";
 
-// Nowy typ: wybór do scalenia
 export type PendingMerge = {
     canvasId: CanvasMetadata["id"];
     label: number;

--- a/src/lib/stores/GlobalState/GlobalState.ts
+++ b/src/lib/stores/GlobalState/GlobalState.ts
@@ -1,6 +1,3 @@
-/* eslint-disable security/detect-object-injection */
-/* eslint-disable no-param-reassign */
-
 import { ActionProduceCallback } from "../immer.helpers";
 import {
     GlobalState as State,
@@ -14,18 +11,20 @@ class StoreClass {
         return this.use.getState();
     }
 
-    private setLastAddedMarking(
-        callback: ActionProduceCallback<State["lastAddedMarking"], State>
+    private setPendingMerge(
+        callback: ActionProduceCallback<State["pendingMerge"], State>
     ) {
         this.state.set(draft => {
-            draft.lastAddedMarking = callback(draft.lastAddedMarking, draft);
+            const updatedValue = callback(draft.pendingMerge, draft);
+            // eslint-disable-next-line no-param-reassign
+            draft.pendingMerge = updatedValue;
         });
     }
 
     readonly actions = {
-        lastAddedMarking: {
-            setLastAddedMarking: (newMarking: State["lastAddedMarking"]) => {
-                this.setLastAddedMarking(() => newMarking);
+        merge: {
+            setPending: (pending: State["pendingMerge"]) => {
+                this.setPendingMerge(() => pending);
             },
         },
     };

--- a/src/lib/stores/MarkingTypes/MarkingTypes.ts
+++ b/src/lib/stores/MarkingTypes/MarkingTypes.ts
@@ -20,7 +20,6 @@ class StoreClass {
                 ) {
                     return;
                 }
-
                 this.state.set(draft => {
                     draft.selectedTypeId = typeId;
                 });

--- a/src/lib/stores/Markings/Markings.ts
+++ b/src/lib/stores/Markings/Markings.ts
@@ -19,7 +19,7 @@ import {
     _createMarkingsStore as createStore,
     MarkingsState as State,
 } from "./Markings.store";
-import { GlobalStateStore } from "../GlobalState";
+// Usunięto GlobalStateStore – synchronizacja labeli nie jest już potrzebna
 import { IDGenerator } from "./IdGenerator";
 
 const useLeftStore = createStore(CANVAS_ID.LEFT);
@@ -44,20 +44,10 @@ class StoreClass {
     private setMarkingsAndUpdateHash(
         callback: ActionProduceCallback<State["markings"], State>
     ) {
-        // Set markings
         this.state.set(draft => {
             const newMarkings = callback(draft.markings, draft);
             draft.markings = newMarkings;
-
-            const lastMarking = newMarkings.at(-1);
-            if (lastMarking !== undefined)
-                GlobalStateStore.actions.lastAddedMarking.setLastAddedMarking({
-                    marking: lastMarking,
-                    canvasId: this.id,
-                });
         });
-
-        // Set new state hash
         this.state.set(draft => {
             draft.markingsHash = crypto.randomUUID();
         });
@@ -85,67 +75,119 @@ class StoreClass {
     readonly actions = {
         labelGenerator: {
             getLabel: () => {
+                // Jeśli użytkownik ma zaznaczony marking i chce nadpisać – użyj jego labelu.
                 if (this.state.selectedMarkingLabel) {
                     return this.state.selectedMarkingLabel;
                 }
-
-                // Last added marking was added to the opposite canvas and doesnt exist in this canvas yet
-                const { lastAddedMarking } = GlobalStateStore.state;
-                if (
-                    lastAddedMarking &&
-                    lastAddedMarking.canvasId !== this.id &&
-                    !this.state.markings.some(
-                        x => x.label === lastAddedMarking.marking.label
-                    )
-                ) {
-                    this.actions.labelGenerator.reset();
-                    return lastAddedMarking.marking.label;
-                }
-
-                // Markings collection for this view already contains a marking with the highest generated id
-                if (
-                    this.state.markings.some(
-                        x => x.label === this.labelGenerator.getCurrentId()
-                    )
-                ) {
-                    // Generate id for the marking
-                    return this.labelGenerator.generateId();
-                }
-
-                // Default safety case
-                return this.labelGenerator.getCurrentId();
-            },
-            getMaxLabel: () => this.labelGenerator.getCurrentId(),
-            reset: () => {
-                this.labelGenerator = new IDGenerator();
-
+                // Oblicz globalny maksymalny label po obu canvasach
                 const oppositeCanvasId = getOppositeCanvasId(this.id);
                 const oppositeCanvasLabels = Store(
                     oppositeCanvasId
                 ).state.markings.map(m => m.label);
                 const thisCanvasLabels = this.state.markings.map(m => m.label);
+                const maxLabelBoth = arrayMax([
+                    ...oppositeCanvasLabels,
+                    ...thisCanvasLabels,
+                ]);
+                const target = maxLabelBoth ?? IDGenerator.initialValue; // gdy brak oznaczeń – start od 1
 
+                // Ustaw wewnętrzny generator, aby był zgodny z globalnym stanem
+                this.labelGenerator.setId(target);
+
+                // Jeśli „ostatni” label jest wolny po tej stronie – użyj go; w przeciwnym razie nowy (max+1)
+                const isTakenHere = this.state.markings.some(
+                    x => x.label === target
+                );
+                return isTakenHere
+                    ? this.labelGenerator.generateId()
+                    : this.labelGenerator.getCurrentId();
+            },
+            getMaxLabel: () => this.labelGenerator.getCurrentId(),
+            reset: () => {
+                this.labelGenerator = new IDGenerator();
+                const oppositeCanvasId = getOppositeCanvasId(this.id);
+                const oppositeCanvasLabels = Store(
+                    oppositeCanvasId
+                ).state.markings.map(m => m.label);
+                const thisCanvasLabels = this.state.markings.map(m => m.label);
                 const maxLabel =
                     arrayMax([...oppositeCanvasLabels, ...thisCanvasLabels]) ??
                     IDGenerator.initialValue;
-
                 this.labelGenerator.setId(maxLabel);
             },
         },
         markings: {
             reset: () => {
+                // Wyczyszczenie oznaczeń na tym canvasie
                 this.setMarkingsAndUpdateHash(() => []);
+
+                // Jeśli oba canvas-y są puste – zresetuj generatory do 1.
+                const oppositeStore = Store(getOppositeCanvasId(this.id));
+                const bothEmpty =
+                    this.state.markings.length === 0 &&
+                    oppositeStore.state.markings.length === 0;
+
+                if (bothEmpty) {
+                    this.actions.labelGenerator.reset();
+                    oppositeStore.actions.labelGenerator.reset();
+                } else {
+                    // Utrzymaj generator zsynchronizowany z maksymalnym istniejącym labelem.
+                    this.actions.labelGenerator.reset();
+                }
             },
             addOne: (marking: MarkingClass) => {
+                // Zadbaj o spójność ids po stronie store – jeśli istnieje marking o tym samym labelu
+                // (tu lub na przeciwnej stronie), użyj jego stabilnych ids.
+                const existingIds = this.actions.markings.findIdsByLabel(
+                    marking.label
+                );
+                const idsToUse =
+                    existingIds && existingIds.length > 0
+                        ? Array.from(new Set(existingIds))
+                        : marking.ids;
+
                 if (this.state.markings.find(m => m.label === marking.label)) {
                     this.setMarkingsAndUpdateHash(markings =>
                         markings.filter(m => m.label !== marking.label)
                     );
                 }
-
                 this.setMarkingsAndUpdateHash(
                     produce(state => {
-                        state.push(marking);
+                        // Utwórz nową instancję odpowiadającą klasie markingu zamiast mutować istniejącą (może być zamrożona)
+                        let mToPush: MarkingClass = marking;
+                        if (marking instanceof PointMarking) {
+                            mToPush = new PointMarking(
+                                marking.label,
+                                marking.origin,
+                                marking.typeId,
+                                idsToUse
+                            );
+                        } else if (marking instanceof RayMarking) {
+                            mToPush = new RayMarking(
+                                marking.label,
+                                marking.origin,
+                                marking.typeId,
+                                (marking as RayMarking).angleRad,
+                                idsToUse
+                            );
+                        } else if (marking instanceof LineSegmentMarking) {
+                            mToPush = new LineSegmentMarking(
+                                marking.label,
+                                marking.origin,
+                                marking.typeId,
+                                (marking as LineSegmentMarking).endpoint,
+                                idsToUse
+                            );
+                        } else if (marking instanceof BoundingBoxMarking) {
+                            mToPush = new BoundingBoxMarking(
+                                marking.label,
+                                marking.origin,
+                                marking.typeId,
+                                (marking as BoundingBoxMarking).endpoint,
+                                idsToUse
+                            );
+                        }
+                        state.push(mToPush);
                     })
                 );
                 this.setSelectedMarkingLabel(() => null);
@@ -153,7 +195,52 @@ class StoreClass {
             addMany: (markings: MarkingClass[]) =>
                 this.setMarkingsAndUpdateHash(
                     produce(state => {
-                        state.push(...markings);
+                        // Przygotuj nowe instancje z właściwymi ids bez mutowania wejściowych obiektów
+                        const prepared = markings.map(m => {
+                            const existingIds =
+                                this.actions.markings.findIdsByLabel(m.label);
+                            const idsToUse =
+                                existingIds && existingIds.length > 0
+                                    ? Array.from(new Set(existingIds))
+                                    : m.ids;
+                            if (m instanceof PointMarking) {
+                                return new PointMarking(
+                                    m.label,
+                                    m.origin,
+                                    m.typeId,
+                                    idsToUse
+                                );
+                            }
+                            if (m instanceof RayMarking) {
+                                return new RayMarking(
+                                    m.label,
+                                    m.origin,
+                                    m.typeId,
+                                    (m as RayMarking).angleRad,
+                                    idsToUse
+                                );
+                            }
+                            if (m instanceof LineSegmentMarking) {
+                                return new LineSegmentMarking(
+                                    m.label,
+                                    m.origin,
+                                    m.typeId,
+                                    (m as LineSegmentMarking).endpoint,
+                                    idsToUse
+                                );
+                            }
+                            if (m instanceof BoundingBoxMarking) {
+                                return new BoundingBoxMarking(
+                                    m.label,
+                                    m.origin,
+                                    m.typeId,
+                                    (m as BoundingBoxMarking).endpoint,
+                                    idsToUse
+                                );
+                            }
+                            return m;
+                        });
+                        state.push(...prepared);
                     })
                 ),
             removeOneByLabel: (label: MarkingClass["label"]) => {
@@ -161,13 +248,115 @@ class StoreClass {
                     this.setSelectedMarkingLabel(() => null);
                 }
 
-                this.setMarkingsAndUpdateHash(markings =>
-                    markings.filter(marking => marking.label !== label)
+                // Oblicz nową listę po usunięciu i zastosuj
+                const filtered = this.state.markings.filter(
+                    marking => marking.label !== label
+                );
+                this.setMarkingsAndUpdateHash(() => filtered);
+
+                // Jeśli ten label nie istnieje już po obu stronach – skompaktuj etykiety globalnie
+                const oppositeStore = Store(getOppositeCanvasId(this.id));
+                const existsOpposite = oppositeStore.state.markings.some(
+                    m => m.label === label
+                );
+                if (!existsOpposite) {
+                    this.actions.markings.compactLabelsAcrossBoth();
+                } else {
+                    // Po usunięciu zsynchronizuj generator etykiet.
+                    const bothEmpty =
+                        filtered.length === 0 &&
+                        oppositeStore.state.markings.length === 0;
+
+                    if (bothEmpty) {
+                        this.actions.labelGenerator.reset();
+                        oppositeStore.actions.labelGenerator.reset();
+                    } else {
+                        this.actions.labelGenerator.reset();
+                    }
+                }
+            },
+            findIdsByLabel: (label: MarkingClass["label"]) => {
+                const own = this.state.markings.find(m => m.label === label);
+                if (own) return own.ids;
+                const opposite = Store(
+                    getOppositeCanvasId(this.id)
+                ).state.markings.find(m => m.label === label);
+                return opposite?.ids;
+            },
+            mergePair: (
+                localLabel: number,
+                otherCanvasId: CANVAS_ID,
+                otherLabel: number
+            ) => {
+                const a = this.state.markings.find(m => m.label === localLabel);
+                const otherStore = Store(otherCanvasId);
+                const b = otherStore.state.markings.find(
+                    m => m.label === otherLabel
+                );
+                if (!a || !b) return;
+
+                const unionIds = Array.from(
+                    new Set([...(a.ids ?? []), ...(b.ids ?? [])])
                 );
 
-                GlobalStateStore.actions.lastAddedMarking.setLastAddedMarking(
+                // Zaktualizuj A (ten store) – zachowuje localLabel i instancję klasy
+                this.setMarkingsAndUpdateHash(markings => {
+                    const m = markings.find(x => x.label === localLabel);
+                    if (m) m.ids = unionIds;
+                    return markings;
+                });
+
+                // Zaktualizuj B (drugi store) – otrzymuje label lokalny i instancję klasy
+                otherStore.setMarkingsAndUpdateHash(markings => {
+                    const m = markings.find(x => x.label === otherLabel);
+                    if (m) {
+                        m.label = localLabel;
+                        m.ids = unionIds;
+                    }
+                    return markings;
+                });
+
+                // Po scaleniach – wyczyść zaznaczenie na obu canvasach
+                this.setSelectedMarkingLabel(() => null);
+                otherStore.actions.selectedMarkingLabel.setSelectedMarkingLabel(
                     null
                 );
+
+                // Po scaleniach – skompaktuj globalnie (może powstać dziura po otherLabel)
+                this.actions.markings.compactLabelsAcrossBoth();
+            },
+            compactLabelsAcrossBoth: () => {
+                const leftStore = Store(CANVAS_ID.LEFT);
+                const rightStore = Store(CANVAS_ID.RIGHT);
+                const all = [
+                    ...leftStore.state.markings,
+                    ...rightStore.state.markings,
+                ];
+                const uniqueSorted = Array.from(
+                    new Set(all.map(m => m.label))
+                ).sort((a, b) => a - b);
+                const mapping = new Map<number, number>();
+                uniqueSorted.forEach((lbl, idx) => mapping.set(lbl, idx + 1));
+
+                const remap = (store: StoreClass) => {
+                    store.setMarkingsAndUpdateHash(markings => {
+                        markings.forEach(m => {
+                            const newLabel = mapping.get(m.label);
+                            if (newLabel && newLabel !== m.label)
+                                m.label = newLabel;
+                        });
+                        return markings;
+                    });
+                    const sel = store.state.selectedMarkingLabel;
+                    if (sel) {
+                        const newSel = mapping.get(sel) ?? null;
+                        store.setSelectedMarkingLabel(() => newSel);
+                    }
+                    store.actions.labelGenerator.reset();
+                };
+
+                remap(leftStore);
+                remap(rightStore);
             },
         },
         temporaryMarking: {

--- a/src/lib/stores/Markings/Markings.ts
+++ b/src/lib/stores/Markings/Markings.ts
@@ -19,7 +19,6 @@ import {
     _createMarkingsStore as createStore,
     MarkingsState as State,
 } from "./Markings.store";
-// Usunięto GlobalStateStore – synchronizacja labeli nie jest już potrzebna
 import { IDGenerator } from "./IdGenerator";
 
 const useLeftStore = createStore(CANVAS_ID.LEFT);
@@ -75,11 +74,11 @@ class StoreClass {
     readonly actions = {
         labelGenerator: {
             getLabel: () => {
-                // Jeśli użytkownik ma zaznaczony marking i chce nadpisać – użyj jego labelu.
+                // If user has selected marking and wants to overwrite - use its label
                 if (this.state.selectedMarkingLabel) {
                     return this.state.selectedMarkingLabel;
                 }
-                // Oblicz globalny maksymalny label po obu canvasach
+                // Calculate global max label across both canvases
                 const oppositeCanvasId = getOppositeCanvasId(this.id);
                 const oppositeCanvasLabels = Store(
                     oppositeCanvasId
@@ -89,12 +88,10 @@ class StoreClass {
                     ...oppositeCanvasLabels,
                     ...thisCanvasLabels,
                 ]);
-                const target = maxLabelBoth ?? IDGenerator.initialValue; // gdy brak oznaczeń – start od 1
+                const target = maxLabelBoth ?? IDGenerator.initialValue; // when no markings - start from 1
 
-                // Ustaw wewnętrzny generator, aby był zgodny z globalnym stanem
                 this.labelGenerator.setId(target);
 
-                // Jeśli „ostatni” label jest wolny po tej stronie – użyj go; w przeciwnym razie nowy (max+1)
                 const isTakenHere = this.state.markings.some(
                     x => x.label === target
                 );
@@ -118,10 +115,8 @@ class StoreClass {
         },
         markings: {
             reset: () => {
-                // Wyczyszczenie oznaczeń na tym canvasie
                 this.setMarkingsAndUpdateHash(() => []);
 
-                // Jeśli oba canvas-y są puste – zresetuj generatory do 1.
                 const oppositeStore = Store(getOppositeCanvasId(this.id));
                 const bothEmpty =
                     this.state.markings.length === 0 &&
@@ -131,13 +126,10 @@ class StoreClass {
                     this.actions.labelGenerator.reset();
                     oppositeStore.actions.labelGenerator.reset();
                 } else {
-                    // Utrzymaj generator zsynchronizowany z maksymalnym istniejącym labelem.
                     this.actions.labelGenerator.reset();
                 }
             },
             addOne: (marking: MarkingClass) => {
-                // Zadbaj o spójność ids po stronie store – jeśli istnieje marking o tym samym labelu
-                // (tu lub na przeciwnej stronie), użyj jego stabilnych ids.
                 const existingIds = this.actions.markings.findIdsByLabel(
                     marking.label
                 );
@@ -153,7 +145,6 @@ class StoreClass {
                 }
                 this.setMarkingsAndUpdateHash(
                     produce(state => {
-                        // Utwórz nową instancję odpowiadającą klasie markingu zamiast mutować istniejącą (może być zamrożona)
                         let mToPush: MarkingClass = marking;
                         if (marking instanceof PointMarking) {
                             mToPush = new PointMarking(
@@ -195,7 +186,6 @@ class StoreClass {
             addMany: (markings: MarkingClass[]) =>
                 this.setMarkingsAndUpdateHash(
                     produce(state => {
-                        // Przygotuj nowe instancje z właściwymi ids bez mutowania wejściowych obiektów
                         const prepared = markings.map(m => {
                             const existingIds =
                                 this.actions.markings.findIdsByLabel(m.label);
@@ -248,13 +238,11 @@ class StoreClass {
                     this.setSelectedMarkingLabel(() => null);
                 }
 
-                // Oblicz nową listę po usunięciu i zastosuj
                 const filtered = this.state.markings.filter(
                     marking => marking.label !== label
                 );
                 this.setMarkingsAndUpdateHash(() => filtered);
 
-                // Jeśli ten label nie istnieje już po obu stronach – skompaktuj etykiety globalnie
                 const oppositeStore = Store(getOppositeCanvasId(this.id));
                 const existsOpposite = oppositeStore.state.markings.some(
                     m => m.label === label
@@ -262,7 +250,6 @@ class StoreClass {
                 if (!existsOpposite) {
                     this.actions.markings.compactLabelsAcrossBoth();
                 } else {
-                    // Po usunięciu zsynchronizuj generator etykiet.
                     const bothEmpty =
                         filtered.length === 0 &&
                         oppositeStore.state.markings.length === 0;
@@ -299,14 +286,12 @@ class StoreClass {
                     new Set([...(a.ids ?? []), ...(b.ids ?? [])])
                 );
 
-                // Zaktualizuj A (ten store) – zachowuje localLabel i instancję klasy
                 this.setMarkingsAndUpdateHash(markings => {
                     const m = markings.find(x => x.label === localLabel);
                     if (m) m.ids = unionIds;
                     return markings;
                 });
 
-                // Zaktualizuj B (drugi store) – otrzymuje label lokalny i instancję klasy
                 otherStore.setMarkingsAndUpdateHash(markings => {
                     const m = markings.find(x => x.label === otherLabel);
                     if (m) {
@@ -316,13 +301,12 @@ class StoreClass {
                     return markings;
                 });
 
-                // Po scaleniach – wyczyść zaznaczenie na obu canvasach
+                // After merging - clear selection on both canvases
                 this.setSelectedMarkingLabel(() => null);
                 otherStore.actions.selectedMarkingLabel.setSelectedMarkingLabel(
                     null
                 );
 
-                // Po scaleniach – skompaktuj globalnie (może powstać dziura po otherLabel)
                 this.actions.markings.compactLabelsAcrossBoth();
             },
             compactLabelsAcrossBoth: () => {

--- a/src/lib/utils/viewport/loadImage.ts
+++ b/src/lib/utils/viewport/loadImage.ts
@@ -22,7 +22,7 @@ import { Sprite } from "pixi.js";
 import { loadSprite } from "./loadSprite";
 
 export async function loadImage(filePath: string, viewport: Viewport) {
-    DashboardToolbarStore.actions.settings.viewport.setLockScaleSync(false);
+    DashboardToolbarStore.actions.settings.viewport.setLockScaleSync(false); //
     DashboardToolbarStore.actions.settings.viewport.setLockedViewport(false);
 
     const canvasId = viewport.name as CanvasMetadata["id"] | null;

--- a/src/lib/utils/viewport/loadMarkingsData.ts
+++ b/src/lib/utils/viewport/loadMarkingsData.ts
@@ -92,35 +92,31 @@ export async function loadMarkingsData(filePath: string, canvasId: CANVAS_ID) {
         return;
     }
 
-    const markings: MarkingClass[] = fileContentJson.data.markings.map(
-        marking => {
+    // Odtwarzanie instancji (tymczasowy placeholder label=0 – nadamy właściwe etykiety poniżej, zaczynając od 1)
+    const importedMarkings: MarkingClass[] = fileContentJson.data.markings.map(
+        (marking: ExportObject["data"]["markings"][0]) => {
+            const baseArgs = [0, marking.origin, marking.typeId] as const; // placeholder label
+            const ids: string[] = Array.isArray(marking.ids)
+                ? marking.ids.filter((id): id is string => id !== undefined)
+                : (marking as { id?: string }).id
+                  ? [(marking as { id?: string }).id!]
+                  : []; // kompatybilność wsteczna
             switch (marking.markingClass) {
                 case MARKING_CLASS.POINT:
-                    return new PointMarking(
-                        marking.label,
-                        marking.origin,
-                        marking.typeId
-                    );
+                    return new PointMarking(...baseArgs, ids);
                 case MARKING_CLASS.RAY:
-                    return new RayMarking(
-                        marking.label,
-                        marking.origin,
-                        marking.typeId,
-                        marking.angleRad!
-                    );
+                    return new RayMarking(...baseArgs, marking.angleRad!, ids);
                 case MARKING_CLASS.LINE_SEGMENT:
                     return new LineSegmentMarking(
-                        marking.label,
-                        marking.origin,
-                        marking.typeId,
-                        marking.endpoint!
+                        ...baseArgs,
+                        marking.endpoint!,
+                        ids
                     );
                 case MARKING_CLASS.BOUNDING_BOX:
                     return new BoundingBoxMarking(
-                        marking.label,
-                        marking.origin,
-                        marking.typeId,
-                        marking.endpoint!
+                        ...baseArgs,
+                        marking.endpoint!,
+                        ids
                     );
                 default:
                     throw new Error(
@@ -130,18 +126,61 @@ export async function loadMarkingsData(filePath: string, canvasId: CANVAS_ID) {
         }
     );
 
-    const existingtypes = MarkingTypesStore.state.types;
+    const oppositeId = getOppositeCanvasId(canvasId);
+    const oppositeMarkings = MarkingsStore(oppositeId).state.markings;
+    const isFirstCanvas = oppositeMarkings.length === 0;
 
-    const requiredTypes = new Map<MarkingType["id"], MARKING_CLASS>(
-        markings.map(marking => [marking.typeId, marking.markingClass])
+    // Mapowanie id->label z przeciwnego canvasa do parowania (wszystkie id)
+    const oppositeIdToLabel = new Map<string, number>();
+    oppositeMarkings.forEach(m =>
+        m.ids.forEach(id => oppositeIdToLabel.set(id, m.label))
     );
 
+    const maxLabelBoth = Math.max(
+        0,
+        ...MarkingsStore(canvasId).state.markings.map(m => m.label),
+        ...oppositeMarkings.map(m => m.label)
+    );
+    let nextLabel = isFirstCanvas ? 1 : maxLabelBoth + 1;
+
+    // Mapa do przechowywania etykiet dla importowanych markingów
+    const markingLabels = new Map<MarkingClass, number>();
+
+    if (isFirstCanvas) {
+        importedMarkings.forEach((marking, idx) => {
+            markingLabels.set(marking, idx + 1); // 1..N
+        });
+    } else {
+        importedMarkings.forEach(marking => {
+            const matchedLabel = marking.ids
+                .map((id: string) => oppositeIdToLabel.get(id))
+                .find(l => l !== undefined);
+            if (matchedLabel !== undefined) {
+                markingLabels.set(marking, matchedLabel);
+            } else {
+                markingLabels.set(marking, nextLabel);
+                nextLabel += 1;
+            }
+        });
+    }
+
+    // Przypisywanie etykiet do markingów
+    importedMarkings.forEach(marking => {
+        const label = markingLabels.get(marking);
+        if (label !== undefined) {
+            Object.assign(marking, { label });
+        }
+    });
+
+    // --- Typy ---
+    const existingtypes = MarkingTypesStore.state.types;
+    const requiredTypes = new Map<MarkingType["id"], MARKING_CLASS>(
+        importedMarkings.map(marking => [marking.typeId, marking.markingClass])
+    );
     const missingtypesIds: string[] = requiredTypes
         .keys()
         .filter(id => !existingtypes.some(c => c.id === id))
         .toArray();
-
-    // If type exists in markings but not in the store
     if (missingtypesIds.length > 0) {
         const confirmed = await confirmFileSelectionDialog(
             t(
@@ -150,34 +189,20 @@ export async function loadMarkingsData(filePath: string, canvasId: CANVAS_ID) {
             ),
             {
                 kind: "warning",
-                title: t("Missing marking types detected", {
-                    ns: "dialog",
-                }),
+                title: t("Missing marking types detected", { ns: "dialog" }),
             }
         );
-
         if (!confirmed) return;
-
-        // importing names from metadata
         const metadataTypes = fileContentJson.metadata?.types;
-
         const typesToAdd: MarkingType[] = [];
         requiredTypes
             .keys()
             .filter(id => missingtypesIds.includes(id))
             .forEach(id => {
                 const markingClass = requiredTypes.get(id)!;
-
-                const metadataTypeName = metadataTypes.find(
-                    o => o.id === id
+                const metadataTypeName = metadataTypes?.find(
+                    (o: { id: string; name?: string }) => o.id === id
                 )?.name;
-
-                // set names according to metadata if non-existent use slice of id
-                /* 
-                    TODO: if typeName is not present display a warning and allow user to name it
-                    As currently if there is no typeName in the import file it will be named as the first 6 characters of the id
-                    breaking the convention of the user naming the types 
-                */
                 typesToAdd.push({
                     id,
                     name: metadataTypeName ?? id.slice(0, 6),
@@ -189,42 +214,31 @@ export async function loadMarkingsData(filePath: string, canvasId: CANVAS_ID) {
                     category: fileContentJson.metadata.workingMode,
                 });
             });
-
         MarkingTypesStore.actions.types.addMany(typesToAdd);
     }
 
     MarkingsStore(canvasId).actions.markings.reset();
-    MarkingsStore(canvasId).actions.markings.addMany(markings);
+    MarkingsStore(canvasId).actions.markings.addMany(importedMarkings);
     MarkingsStore(canvasId).actions.labelGenerator.reset();
-    MarkingsStore(getOppositeCanvasId(canvasId)).actions.labelGenerator.reset();
+    MarkingsStore(oppositeId).actions.labelGenerator.reset();
 }
 
 export async function loadMarkingsDataWithDialog(viewport: Viewport) {
     try {
         const filePath = await openFileSelectionDialog({
-            title: t("Load markings data from file", {
-                ns: "tooltip",
-            }),
-            filters: [
-                {
-                    name: "Markings data file",
-                    extensions: ["json"],
-                },
-            ],
+            title: t("Load markings data from file", { ns: "tooltip" }),
+            filters: [{ name: "Markings data file", extensions: ["json"] }],
             directory: false,
             canCreateDirectories: false,
             multiple: false,
         });
-
         if (filePath === null) return;
-
         const canvasId = viewport.name as CanvasMetadata["id"] | null;
         if (canvasId === null) {
             showErrorDialog(`Canvas ID: ${canvasId} not found`);
             return;
         }
-
-        await loadMarkingsData(filePath, canvasId);
+        await loadMarkingsData(filePath, canvasId as CANVAS_ID);
     } catch (error) {
         showErrorDialog(error);
     }

--- a/src/lib/utils/viewport/loadMarkingsData.ts
+++ b/src/lib/utils/viewport/loadMarkingsData.ts
@@ -92,7 +92,7 @@ export async function loadMarkingsData(filePath: string, canvasId: CANVAS_ID) {
         return;
     }
 
-    // Odtwarzanie instancji (tymczasowy placeholder label=0 – nadamy właściwe etykiety poniżej, zaczynając od 1)
+    // Recreate instances (temporary placeholder label=0 - we'll assign proper labels below, starting from 1)
     const importedMarkings: MarkingClass[] = fileContentJson.data.markings.map(
         (marking: ExportObject["data"]["markings"][0]) => {
             const baseArgs = [0, marking.origin, marking.typeId] as const; // placeholder label
@@ -100,7 +100,7 @@ export async function loadMarkingsData(filePath: string, canvasId: CANVAS_ID) {
                 ? marking.ids.filter((id): id is string => id !== undefined)
                 : (marking as { id?: string }).id
                   ? [(marking as { id?: string }).id!]
-                  : []; // kompatybilność wsteczna
+                  : [];
             switch (marking.markingClass) {
                 case MARKING_CLASS.POINT:
                     return new PointMarking(...baseArgs, ids);
@@ -130,7 +130,6 @@ export async function loadMarkingsData(filePath: string, canvasId: CANVAS_ID) {
     const oppositeMarkings = MarkingsStore(oppositeId).state.markings;
     const isFirstCanvas = oppositeMarkings.length === 0;
 
-    // Mapowanie id->label z przeciwnego canvasa do parowania (wszystkie id)
     const oppositeIdToLabel = new Map<string, number>();
     oppositeMarkings.forEach(m =>
         m.ids.forEach(id => oppositeIdToLabel.set(id, m.label))
@@ -143,7 +142,6 @@ export async function loadMarkingsData(filePath: string, canvasId: CANVAS_ID) {
     );
     let nextLabel = isFirstCanvas ? 1 : maxLabelBoth + 1;
 
-    // Mapa do przechowywania etykiet dla importowanych markingów
     const markingLabels = new Map<MarkingClass, number>();
 
     if (isFirstCanvas) {
@@ -164,7 +162,7 @@ export async function loadMarkingsData(filePath: string, canvasId: CANVAS_ID) {
         });
     }
 
-    // Przypisywanie etykiet do markingów
+    // Assign labels to markings
     importedMarkings.forEach(marking => {
         const label = markingLabels.get(marking);
         if (label !== undefined) {
@@ -172,7 +170,6 @@ export async function loadMarkingsData(filePath: string, canvasId: CANVAS_ID) {
         }
     });
 
-    // --- Typy ---
     const existingtypes = MarkingTypesStore.state.types;
     const requiredTypes = new Map<MarkingType["id"], MARKING_CLASS>(
         importedMarkings.map(marking => [marking.typeId, marking.markingClass])

--- a/src/lib/utils/viewport/saveMarkingsDataWithDialog.ts
+++ b/src/lib/utils/viewport/saveMarkingsDataWithDialog.ts
@@ -44,7 +44,7 @@ export type ExportObject = {
     };
     data: {
         markings: {
-            ids: MarkingClass["ids"]; // stabilne ID-y (może być wiele)
+            ids: MarkingClass["ids"];
             markingClass: MarkingClass["markingClass"];
             origin: MarkingClass["origin"];
             typeId: MarkingClass["typeId"];

--- a/src/lib/utils/viewport/saveMarkingsDataWithDialog.ts
+++ b/src/lib/utils/viewport/saveMarkingsDataWithDialog.ts
@@ -34,25 +34,17 @@ type ImageInfo = {
     };
 };
 
-type SoftwareInfo = {
-    name: string;
-    version: string;
-};
-
 export type ExportObject = {
     metadata: {
-        software: SoftwareInfo;
+        software: { name: string; version: string };
         image: ImageInfo | null;
         compared_image: ImageInfo | null;
         workingMode: WORKING_MODE;
-        types: {
-            id: string;
-            name: string;
-        }[];
+        types: { id: string; name: string }[];
     };
     data: {
         markings: {
-            label: MarkingClass["label"];
+            ids: MarkingClass["ids"]; // stabilne ID-y (może być wiele)
             markingClass: MarkingClass["markingClass"];
             origin: MarkingClass["origin"];
             typeId: MarkingClass["typeId"];
@@ -118,15 +110,25 @@ async function getData(
                             CANVAS_ID.RIGHT
                         )
                 )
-                .map(c => {
-                    return {
-                        id: c.id,
-                        name: c.name,
-                    };
-                }),
+                .map(c => ({ id: c.id, name: c.name })),
         },
         data: {
-            markings,
+            markings: markings.map(m => ({
+                ids: m.ids,
+                markingClass: m.markingClass,
+                origin: m.origin,
+                typeId: m.typeId,
+                ...("angleRad" in m
+                    ? { angleRad: (m as RayMarking).angleRad }
+                    : {}),
+                ...("endpoint" in m
+                    ? {
+                          endpoint: (
+                              m as LineSegmentMarking | BoundingBoxMarking
+                          ).endpoint,
+                      }
+                    : {}),
+            })),
         },
     };
 


### PR DESCRIPTION
- Labels are now cosmetic only
- Markings can have multiple ids and ids are consistent when saving two files
- Markings with matching ids will have matching labels
- Added button to fuse two markings together

Closes #87, #88