### PR TITLE
fix(settings): sync working mode to marking types settings window

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,6 +4,19 @@
 use tauri::Emitter;
 use tauri::Manager;
 use std::fs;
+use std::sync::Mutex;
+
+struct WorkingModeState(Mutex<Option<String>>);
+
+#[tauri::command]
+fn set_working_mode(state: tauri::State<WorkingModeState>, mode: String) {
+    *state.0.lock().unwrap() = Some(mode);
+}
+
+#[tauri::command]
+fn get_working_mode(state: tauri::State<WorkingModeState>) -> Option<String> {
+    state.0.lock().unwrap().clone()
+}
 
 #[cfg(target_os = "windows")]
 use winreg::enums::HKEY_LOCAL_MACHINE;
@@ -199,6 +212,7 @@ fn read_os_machine_id() -> Option<String> {
 
 fn main() {
     let mut builder = tauri::Builder::default()
+        .manage(WorkingModeState(Mutex::new(None)))
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_fs::init())
@@ -217,6 +231,8 @@ fn main() {
             open_settings_window,
             open_edit_window,
             get_machine_id,
+            set_working_mode,
+            get_working_mode,
         ]);
 
     #[cfg(target_os = "windows")]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,12 +10,12 @@ struct WorkingModeState(Mutex<Option<String>>);
 
 #[tauri::command]
 fn set_working_mode(state: tauri::State<WorkingModeState>, mode: String) {
-    *state.0.lock().unwrap() = Some(mode);
+    *state.0.lock().unwrap_or_else(|e| e.into_inner()) = Some(mode);
 }
 
 #[tauri::command]
 fn get_working_mode(state: tauri::State<WorkingModeState>) -> Option<String> {
-    state.0.lock().unwrap().clone()
+    state.0.lock().unwrap_or_else(|e| e.into_inner()).clone()
 }
 
 #[cfg(target_os = "windows")]

--- a/src/components/settings-window/categories/marking-types-settings.tsx
+++ b/src/components/settings-window/categories/marking-types-settings.tsx
@@ -85,7 +85,8 @@ export function MarkingTypesSettings() {
                             )}
                         >
                             <span className="text-sm">
-                                {selectedCategory ?? t("Working mode")}
+                                {t(selectedCategory, { ns: "modes" }) ??
+                                    t("Working mode")}
                             </span>
                             <ChevronDown size={14} />
                         </DropdownMenuTrigger>
@@ -98,7 +99,7 @@ export function MarkingTypesSettings() {
                                             setSelectedCategory(mode)
                                         }
                                     >
-                                        {mode}
+                                        {t(mode, { ns: "modes" })}
                                     </DropdownMenuItem>
                                 ))}
                             </DropdownMenuContent>

--- a/src/components/settings-window/categories/marking-types-settings.tsx
+++ b/src/components/settings-window/categories/marking-types-settings.tsx
@@ -287,9 +287,9 @@ export function MarkingTypesSettings() {
                                         colSpan={8}
                                         className="text-center py-8 text-muted-foreground"
                                     >
-                                        {selectedCategory
-                                            ? t("Types")
-                                            : t("Working mode")}
+                                        {t(
+                                            "No marking types found for the selected working mode"
+                                        )}
                                     </TableCell>
                                 </TableRow>
                             ) : (

--- a/src/components/settings-window/categories/marking-types-settings.tsx
+++ b/src/components/settings-window/categories/marking-types-settings.tsx
@@ -5,7 +5,14 @@ import { useTranslation } from "react-i18next";
 import { useDebouncedCallback } from "use-debounce";
 import { MarkingTypesStore } from "@/lib/stores/MarkingTypes/MarkingTypes";
 import { TableCell, TableHead, TableRow } from "@/components/ui/table";
-import { Trash2, Download, Upload, Plus, ChevronDown } from "lucide-react";
+import {
+    Trash2,
+    Download,
+    Upload,
+    Plus,
+    ChevronDown,
+    LayoutGrid,
+} from "lucide-react";
 import { ICON, IS_DEV_ENVIRONMENT } from "@/lib/utils/const";
 import { Toggle } from "@/components/ui/toggle";
 import { CANVAS_ID } from "@/components/pixi/canvas/hooks/useCanvasContext";
@@ -85,8 +92,13 @@ export function MarkingTypesSettings() {
                             )}
                         >
                             <span className="text-sm">
-                                {t(selectedCategory, { ns: "modes" }) ??
-                                    t("Working mode")}
+                                {selectedCategory ? (
+                                    t(selectedCategory, { ns: "modes" })
+                                ) : (
+                                    <span className="text-muted-foreground">
+                                        {t("Select working mode")}
+                                    </span>
+                                )}
                             </span>
                             <ChevronDown size={14} />
                         </DropdownMenuTrigger>
@@ -221,208 +233,221 @@ export function MarkingTypesSettings() {
             </div>
 
             <div className="flex-1 overflow-auto">
-                <table className="w-full">
-                    <thead className="sticky top-0 bg-card z-10">
-                        <TableRow className={cn("bg-card border-b")}>
-                            <TableHead className="text-center text-card-foreground whitespace-nowrap">
-                                {t(`MarkingType.Keys.displayName`, {
-                                    ns: "object",
-                                })}
-                            </TableHead>
-                            <TableHead className="text-center text-card-foreground whitespace-nowrap">
-                                {t(`MarkingType.Keys.name`, {
-                                    ns: "object",
-                                })}
-                            </TableHead>
-                            <TableHead className="text-center text-card-foreground whitespace-nowrap">
-                                {t(`MarkingType.Keys.markingClass`, {
-                                    ns: "object",
-                                })}
-                            </TableHead>
-                            <TableHead className="text-center text-card-foreground whitespace-nowrap">
-                                {t(`MarkingType.Keys.backgroundColor`, {
-                                    ns: "object",
-                                })}
-                            </TableHead>
-                            <TableHead className="text-center text-card-foreground whitespace-nowrap">
-                                {t(`MarkingType.Keys.textColor`, {
-                                    ns: "object",
-                                })}
-                            </TableHead>
-                            <TableHead className="text-center text-card-foreground whitespace-nowrap">
-                                {t(`MarkingType.Keys.size`, {
-                                    ns: "object",
-                                })}
-                            </TableHead>
-                            <TableHead className="text-center text-card-foreground whitespace-nowrap">
-                                {t("Keybinding", { ns: "keybindings" })}
-                            </TableHead>
-                            {IS_DEV_ENVIRONMENT && <TableHead />}
-                        </TableRow>
-                    </thead>
-                    <tbody>
-                        {types.length === 0 ? (
-                            <TableRow>
-                                <TableCell
-                                    colSpan={8}
-                                    className="text-center py-8 text-muted-foreground"
-                                >
-                                    {selectedCategory
-                                        ? t("Types")
-                                        : t("Working mode")}
-                                </TableCell>
+                {selectedCategory === undefined ? (
+                    <div className="flex flex-col items-center text-center gap-2 border border-dashed py-8 rounded-lg">
+                        <LayoutGrid className="size-12" />
+                        <p>
+                            {t("Select a working mode to view marking types")}
+                        </p>
+                    </div>
+                ) : (
+                    <table className="w-full">
+                        <thead className="sticky top-0 bg-card z-10">
+                            <TableRow className={cn("bg-card border-b")}>
+                                <TableHead className="text-center text-card-foreground whitespace-nowrap">
+                                    {t(`MarkingType.Keys.displayName`, {
+                                        ns: "object",
+                                    })}
+                                </TableHead>
+                                <TableHead className="text-center text-card-foreground whitespace-nowrap">
+                                    {t(`MarkingType.Keys.name`, {
+                                        ns: "object",
+                                    })}
+                                </TableHead>
+                                <TableHead className="text-center text-card-foreground whitespace-nowrap">
+                                    {t(`MarkingType.Keys.markingClass`, {
+                                        ns: "object",
+                                    })}
+                                </TableHead>
+                                <TableHead className="text-center text-card-foreground whitespace-nowrap">
+                                    {t(`MarkingType.Keys.backgroundColor`, {
+                                        ns: "object",
+                                    })}
+                                </TableHead>
+                                <TableHead className="text-center text-card-foreground whitespace-nowrap">
+                                    {t(`MarkingType.Keys.textColor`, {
+                                        ns: "object",
+                                    })}
+                                </TableHead>
+                                <TableHead className="text-center text-card-foreground whitespace-nowrap">
+                                    {t(`MarkingType.Keys.size`, {
+                                        ns: "object",
+                                    })}
+                                </TableHead>
+                                <TableHead className="text-center text-card-foreground whitespace-nowrap">
+                                    {t("Keybinding", { ns: "keybindings" })}
+                                </TableHead>
+                                {IS_DEV_ENVIRONMENT && <TableHead />}
                             </TableRow>
-                        ) : (
-                            types.map(item => (
-                                <TableRow key={item.id}>
-                                    <TableCell>
-                                        <Input
-                                            className="h-6 !p-0 text-center"
-                                            title={`${t("MarkingType.Keys.name", { ns: "object" })}`}
-                                            type="text"
-                                            value={item.displayName}
-                                            onChange={e => {
-                                                setType(item.id, {
-                                                    displayName: e.target.value,
-                                                });
-                                            }}
-                                        />
+                        </thead>
+                        <tbody>
+                            {types.length === 0 ? (
+                                <TableRow>
+                                    <TableCell
+                                        colSpan={8}
+                                        className="text-center py-8 text-muted-foreground"
+                                    >
+                                        {selectedCategory
+                                            ? t("Types")
+                                            : t("Working mode")}
                                     </TableCell>
-                                    <TableCell>
-                                        {IS_DEV_ENVIRONMENT ? (
+                                </TableRow>
+                            ) : (
+                                types.map(item => (
+                                    <TableRow key={item.id}>
+                                        <TableCell>
                                             <Input
                                                 className="h-6 !p-0 text-center"
                                                 title={`${t("MarkingType.Keys.name", { ns: "object" })}`}
                                                 type="text"
-                                                value={item.name}
+                                                value={item.displayName}
                                                 onChange={e => {
                                                     setType(item.id, {
-                                                        name: e.target.value,
+                                                        displayName:
+                                                            e.target.value,
                                                     });
                                                 }}
                                             />
-                                        ) : (
-                                            <span className="p-1 cursor-default">
-                                                {item.name}
-                                            </span>
-                                        )}
-                                    </TableCell>
-                                    <TableCell
-                                        className={cn(
-                                            "p-1 cursor-default text-center"
-                                        )}
-                                    >
-                                        {t(
-                                            `Marking.Keys.markingClass.Keys.${item.markingClass}`,
-                                            {
-                                                ns: "object",
-                                            }
-                                        )}
-                                    </TableCell>
-                                    <TableCell>
-                                        <Input
-                                            className="size-6 cursor-pointer m-auto"
-                                            title={`${t("MarkingType.Keys.backgroundColor", { ns: "object" })}`}
-                                            type="color"
-                                            value={
-                                                item.backgroundColor as string
-                                            }
-                                            onChange={e => {
-                                                setType(item.id, {
-                                                    backgroundColor:
-                                                        e.target.value,
-                                                });
-                                            }}
-                                        />
-                                    </TableCell>
-                                    <TableCell>
-                                        <Input
-                                            className="size-6 cursor-pointer m-auto"
-                                            title={`${t("MarkingType.Keys.textColor", { ns: "object" })}`}
-                                            type="color"
-                                            value={item.textColor as string}
-                                            onChange={e => {
-                                                setType(item.id, {
-                                                    textColor: e.target.value,
-                                                });
-                                            }}
-                                        />
-                                    </TableCell>
-                                    <TableCell>
-                                        <Input
-                                            className="w-24 h-6 !p-0 text-center m-auto"
-                                            min={6}
-                                            max={32}
-                                            width={12}
-                                            title={`${t("MarkingType.Keys.size", { ns: "object" })}`}
-                                            type="number"
-                                            value={item.size}
-                                            onChange={e => {
-                                                setType(item.id, {
-                                                    size: Number(
-                                                        e.target.value
-                                                    ),
-                                                });
-                                            }}
-                                        />
-                                    </TableCell>
-                                    <TableCell>
-                                        <TypeKeybinding
-                                            boundKey={
-                                                keybindings.find(
-                                                    k => k.typeId === item.id
-                                                )?.boundKey ?? undefined
-                                            }
-                                            workingMode={item.category}
-                                            typeId={item.id}
-                                        />
-                                    </TableCell>
-                                    {IS_DEV_ENVIRONMENT && (
-                                        <TableCell>
-                                            <Toggle
-                                                title={t("Remove")}
-                                                className="m-auto"
-                                                size="icon"
-                                                variant="outline"
-                                                pressed={false}
-                                                disabled={
-                                                    MarkingTypesStore.actions.types.checkIfTypeIsInUse(
-                                                        item.id,
-                                                        CANVAS_ID.LEFT
-                                                    ) ||
-                                                    MarkingTypesStore.actions.types.checkIfTypeIsInUse(
-                                                        item.id,
-                                                        CANVAS_ID.RIGHT
-                                                    )
-                                                }
-                                                onClickCapture={() => {
-                                                    MarkingTypesStore.actions.types.removeById(
-                                                        item.id
-                                                    );
-
-                                                    KeybindingsStore.actions.typesKeybindings.remove(
-                                                        item.id,
-                                                        item.category
-                                                    );
-
-                                                    emitMarkingTypesChange();
-                                                }}
-                                            >
-                                                <Trash2
-                                                    className="hover:text-destructive"
-                                                    size={ICON.SIZE}
-                                                    strokeWidth={
-                                                        ICON.STROKE_WIDTH
-                                                    }
-                                                />
-                                            </Toggle>
                                         </TableCell>
-                                    )}
-                                </TableRow>
-                            ))
-                        )}
-                    </tbody>
-                </table>
+                                        <TableCell>
+                                            {IS_DEV_ENVIRONMENT ? (
+                                                <Input
+                                                    className="h-6 !p-0 text-center"
+                                                    title={`${t("MarkingType.Keys.name", { ns: "object" })}`}
+                                                    type="text"
+                                                    value={item.name}
+                                                    onChange={e => {
+                                                        setType(item.id, {
+                                                            name: e.target
+                                                                .value,
+                                                        });
+                                                    }}
+                                                />
+                                            ) : (
+                                                <span className="p-1 cursor-default">
+                                                    {item.name}
+                                                </span>
+                                            )}
+                                        </TableCell>
+                                        <TableCell
+                                            className={cn(
+                                                "p-1 cursor-default text-center"
+                                            )}
+                                        >
+                                            {t(
+                                                `Marking.Keys.markingClass.Keys.${item.markingClass}`,
+                                                {
+                                                    ns: "object",
+                                                }
+                                            )}
+                                        </TableCell>
+                                        <TableCell>
+                                            <Input
+                                                className="size-6 cursor-pointer m-auto"
+                                                title={`${t("MarkingType.Keys.backgroundColor", { ns: "object" })}`}
+                                                type="color"
+                                                value={
+                                                    item.backgroundColor as string
+                                                }
+                                                onChange={e => {
+                                                    setType(item.id, {
+                                                        backgroundColor:
+                                                            e.target.value,
+                                                    });
+                                                }}
+                                            />
+                                        </TableCell>
+                                        <TableCell>
+                                            <Input
+                                                className="size-6 cursor-pointer m-auto"
+                                                title={`${t("MarkingType.Keys.textColor", { ns: "object" })}`}
+                                                type="color"
+                                                value={item.textColor as string}
+                                                onChange={e => {
+                                                    setType(item.id, {
+                                                        textColor:
+                                                            e.target.value,
+                                                    });
+                                                }}
+                                            />
+                                        </TableCell>
+                                        <TableCell>
+                                            <Input
+                                                className="w-24 h-6 !p-0 text-center m-auto"
+                                                min={6}
+                                                max={32}
+                                                width={12}
+                                                title={`${t("MarkingType.Keys.size", { ns: "object" })}`}
+                                                type="number"
+                                                value={item.size}
+                                                onChange={e => {
+                                                    setType(item.id, {
+                                                        size: Number(
+                                                            e.target.value
+                                                        ),
+                                                    });
+                                                }}
+                                            />
+                                        </TableCell>
+                                        <TableCell>
+                                            <TypeKeybinding
+                                                boundKey={
+                                                    keybindings.find(
+                                                        k =>
+                                                            k.typeId === item.id
+                                                    )?.boundKey ?? undefined
+                                                }
+                                                workingMode={item.category}
+                                                typeId={item.id}
+                                            />
+                                        </TableCell>
+                                        {IS_DEV_ENVIRONMENT && (
+                                            <TableCell>
+                                                <Toggle
+                                                    title={t("Remove")}
+                                                    className="m-auto"
+                                                    size="icon"
+                                                    variant="outline"
+                                                    pressed={false}
+                                                    disabled={
+                                                        MarkingTypesStore.actions.types.checkIfTypeIsInUse(
+                                                            item.id,
+                                                            CANVAS_ID.LEFT
+                                                        ) ||
+                                                        MarkingTypesStore.actions.types.checkIfTypeIsInUse(
+                                                            item.id,
+                                                            CANVAS_ID.RIGHT
+                                                        )
+                                                    }
+                                                    onClickCapture={() => {
+                                                        MarkingTypesStore.actions.types.removeById(
+                                                            item.id
+                                                        );
+
+                                                        KeybindingsStore.actions.typesKeybindings.remove(
+                                                            item.id,
+                                                            item.category
+                                                        );
+
+                                                        emitMarkingTypesChange();
+                                                    }}
+                                                >
+                                                    <Trash2
+                                                        className="hover:text-destructive"
+                                                        size={ICON.SIZE}
+                                                        strokeWidth={
+                                                            ICON.STROKE_WIDTH
+                                                        }
+                                                    />
+                                                </Toggle>
+                                            </TableCell>
+                                        )}
+                                    </TableRow>
+                                ))
+                            )}
+                        </tbody>
+                    </table>
+                )}
             </div>
         </div>
     );

--- a/src/components/settings-window/categories/marking-types-settings.tsx
+++ b/src/components/settings-window/categories/marking-types-settings.tsx
@@ -34,9 +34,9 @@ import { invoke } from "@tauri-apps/api/core";
 export function MarkingTypesSettings() {
     const { t } = useTranslation();
 
-    const [selectedCategory, setSelectedCategory] = useState<WORKING_MODE>(
-        WORKING_MODE.FINGERPRINT
-    );
+    const [selectedCategory, setSelectedCategory] = useState<
+        WORKING_MODE | undefined
+    >(undefined);
 
     useEffect(() => {
         invoke<WORKING_MODE | null>("get_working_mode").then(mode => {

--- a/src/components/settings-window/categories/marking-types-settings.tsx
+++ b/src/components/settings-window/categories/marking-types-settings.tsx
@@ -29,30 +29,19 @@ import {
 } from "@/lib/markings/MarkingType";
 import { useState, useEffect } from "react";
 import { emitMarkingTypesChange } from "@/lib/hooks/useSettingsSync";
+import { invoke } from "@tauri-apps/api/core";
 
 export function MarkingTypesSettings() {
     const { t } = useTranslation();
 
-    const urlParams = new URLSearchParams(window.location.search);
-    const urlWorkingMode = urlParams.get("workingMode") as WORKING_MODE | null;
-
-    const [selectedCategory, setSelectedCategory] =
-        useState<WORKING_MODE | null>(urlWorkingMode);
+    const [selectedCategory, setSelectedCategory] = useState<WORKING_MODE>(
+        WORKING_MODE.FINGERPRINT
+    );
 
     useEffect(() => {
-        const handleLocationChange = () => {
-            const params = new URLSearchParams(window.location.search);
-            const mode = params.get("workingMode") as WORKING_MODE | null;
-            if (mode) {
-                setSelectedCategory(mode);
-            }
-        };
-
-        window.addEventListener("popstate", handleLocationChange);
-
-        return () => {
-            window.removeEventListener("popstate", handleLocationChange);
-        };
+        invoke<WORKING_MODE | null>("get_working_mode").then(mode => {
+            if (mode) setSelectedCategory(mode);
+        });
     }, []);
 
     const types = MarkingTypesStore.use(state =>

--- a/src/lib/locales/en/keywords.ts
+++ b/src/lib/locales/en/keywords.ts
@@ -75,6 +75,8 @@ const d: Dictionary = {
     Apply: "Apply",
     Clear: "Clear",
     "Select working mode": "Select working mode",
+    "No marking types found for the selected working mode":
+        "No marking types found for the selected working mode",
     "Select a working mode to view marking types":
         "Select a working mode to view marking types",
 };

--- a/src/lib/locales/en/keywords.ts
+++ b/src/lib/locales/en/keywords.ts
@@ -74,6 +74,9 @@ const d: Dictionary = {
     Edit: "Edit",
     Apply: "Apply",
     Clear: "Clear",
+    "Select working mode": "Select working mode",
+    "Select a working mode to view marking types":
+        "Select a working mode to view marking types",
 };
 
 export default d;

--- a/src/lib/locales/pl/keywords.ts
+++ b/src/lib/locales/pl/keywords.ts
@@ -74,6 +74,9 @@ const d: Dictionary = {
     Edit: "Edycja",
     Apply: "Zastosuj",
     Clear: "Wyczyść",
+    "Select working mode": "Wybierz tryb pracy",
+    "Select a working mode to view marking types":
+        "Wybierz tryb pracy, aby wyświetlić typy adnotacji",
 };
 
 export default d;

--- a/src/lib/locales/pl/keywords.ts
+++ b/src/lib/locales/pl/keywords.ts
@@ -75,6 +75,8 @@ const d: Dictionary = {
     Apply: "Zastosuj",
     Clear: "Wyczyść",
     "Select working mode": "Wybierz tryb pracy",
+    "No marking types found for the selected working mode":
+        "Nie znaleziono typów adnotacji dla wybranego trybu pracy",
     "Select a working mode to view marking types":
         "Wybierz tryb pracy, aby wyświetlić typy adnotacji",
 };

--- a/src/lib/locales/translation.ts
+++ b/src/lib/locales/translation.ts
@@ -83,6 +83,8 @@ export type i18nKeywords = Recordify<
     | "Edit"
     | "Apply"
     | "Clear"
+    | "Select a working mode to view marking types"
+    | "Select working mode"
 >;
 
 export type i18nDescription = Recordify<

--- a/src/lib/locales/translation.ts
+++ b/src/lib/locales/translation.ts
@@ -85,6 +85,7 @@ export type i18nKeywords = Recordify<
     | "Clear"
     | "Select a working mode to view marking types"
     | "Select working mode"
+    | "No marking types found for the selected working mode"
 >;
 
 export type i18nDescription = Recordify<

--- a/src/lib/stores/WorkingMode/WorkingMode.store.ts
+++ b/src/lib/stores/WorkingMode/WorkingMode.store.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 import { createJSONStorage, devtools } from "zustand/middleware";
 import { WORKING_MODE } from "@/views/selectMode";
 import { tauriStorage } from "@/lib/stores/tauri-storage-adapter.helpers";
+import { invoke } from "@tauri-apps/api/core";
 
 const STORE_NAME = "working-mode";
 const STORE_FILE = new LazyStore(`${STORE_NAME}.dat`);
@@ -21,9 +22,14 @@ const useWorkingModeStore = create<State>()(
     devtools(
         set => ({
             ...INITIAL_STATE,
-            setWorkingMode: mode => set(() => ({ workingMode: mode })),
-            resetWorkingMode: () =>
-                set(() => ({ workingMode: INITIAL_STATE.workingMode })),
+            setWorkingMode: mode => {
+                invoke("set_working_mode", { mode });
+                set(() => ({ workingMode: mode }));
+            },
+            resetWorkingMode: () => {
+                invoke("set_working_mode", { mode: INITIAL_STATE.workingMode });
+                set(() => ({ workingMode: INITIAL_STATE.workingMode }));
+            },
         }),
         {
             name: STORE_NAME,


### PR DESCRIPTION
1. add rust in-memory state to share working mode across tauri windows                                                                                                                                                                       
2. settings window now opens on the correct working mode tab (defaults - fingerprint)                                                                                                                                               
3. fix missing translations for working mode names in select field