### PR TITLE
feat(settings): add delete and reorder to marking types

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     },
     "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop-flourish": "1.1.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@pixi/core": "7.4.3",
         "@pixi/react": "7.1.0",
         "@pixi/text-bitmap": "7.4.3",

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     },
     "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop-flourish": "1.1.0",
-        "@dnd-kit/core": "^6.3.1",
-        "@dnd-kit/sortable": "^10.0.0",
-        "@dnd-kit/utilities": "^3.2.2",
+        "@dnd-kit/core": "6.3.1",
+        "@dnd-kit/sortable": "10.0.0",
+        "@dnd-kit/utilities": "3.2.2",
         "@pixi/core": "7.4.3",
         "@pixi/react": "7.1.0",
         "@pixi/text-bitmap": "7.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,15 @@ dependencies:
   '@atlaskit/pragmatic-drag-and-drop-flourish':
     specifier: 1.1.0
     version: 1.1.0(@types/react@18.2.69)(react@18.2.0)
+  '@dnd-kit/core':
+    specifier: ^6.3.1
+    version: 6.3.1(react-dom@18.2.0)(react@18.2.0)
+  '@dnd-kit/sortable':
+    specifier: ^10.0.0
+    version: 10.0.0(@dnd-kit/core@6.3.1)(react@18.2.0)
+  '@dnd-kit/utilities':
+    specifier: ^3.2.2
+    version: 3.2.2(react@18.2.0)
   '@pixi/core':
     specifier: 7.4.3
     version: 7.4.3
@@ -943,6 +952,49 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  /@dnd-kit/accessibility@3.1.1(react@18.2.0):
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+    dependencies:
+      react: 18.2.0
+      tslib: 2.8.1
+    dev: false
+
+  /@dnd-kit/core@6.3.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@18.2.0)
+      '@dnd-kit/utilities': 3.2.2(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      tslib: 2.8.1
+    dev: false
+
+  /@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1)(react@18.2.0):
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@18.2.0)(react@18.2.0)
+      '@dnd-kit/utilities': 3.2.2(react@18.2.0)
+      react: 18.2.0
+      tslib: 2.8.1
+    dev: false
+
+  /@dnd-kit/utilities@3.2.2(react@18.2.0):
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
+    dependencies:
+      react: 18.2.0
+      tslib: 2.8.1
+    dev: false
 
   /@emnapi/core@1.4.4:
     resolution: {integrity: sha512-A9CnAbC6ARNMKcIcrQwq6HeHCjpcBZ5wSx4U01WXCqEKlrzB9F9315WDNHkrs2xbx7YjjSxbUYxuN6EQzpcY2g==}

--- a/src/components/settings-window/categories/marking-types-settings.tsx
+++ b/src/components/settings-window/categories/marking-types-settings.tsx
@@ -1,103 +1,21 @@
-/* eslint-disable security/detect-object-injection */
-import { cn } from "@/lib/utils/shadcn";
-import { Input } from "@/components/ui/input";
 import { useTranslation } from "react-i18next";
-import { useDebouncedCallback } from "use-debounce";
-import { MarkingTypesStore } from "@/lib/stores/MarkingTypes/MarkingTypes";
-import { TableCell, TableHead, TableRow } from "@/components/ui/table";
-import {
-    Trash2,
-    Download,
-    Upload,
-    Plus,
-    ChevronDown,
-    LayoutGrid,
-} from "lucide-react";
-import { ICON, IS_DEV_ENVIRONMENT } from "@/lib/utils/const";
-import { Toggle } from "@/components/ui/toggle";
-import { CANVAS_ID } from "@/components/pixi/canvas/hooks/useCanvasContext";
-import { WORKING_MODE } from "@/views/selectMode";
-import TypeKeybinding from "@/components/dialogs/marking-types/marking-type-keybinding";
-import { KeybindingsStore } from "@/lib/stores/Keybindings";
-import { exportMarkingTypesWithDialog } from "@/components/dialogs/marking-types/exportMarkingTypesWithDialog";
-import { importMarkingTypesWithDialog } from "@/components/dialogs/marking-types/importMarkingTypesWithDialog";
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuPortal,
-    DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { MARKING_CLASS } from "@/lib/markings/MARKING_CLASS";
-import {
-    defaultBackgroundColor,
-    defaultSize,
-    defaultTextColor,
-} from "@/lib/markings/MarkingType";
-import { useState, useEffect } from "react";
-import {
-    emitMarkingTypesChange,
-    emitKeybindingsChange,
-} from "@/lib/hooks/useSettingsSync";
-import { invoke } from "@tauri-apps/api/core";
+import { useMarkingTypes } from "./marking-types/use-marking-types";
+import { MarkingTypesToolbar } from "./marking-types/toolbar";
+import { MarkingTypesTable } from "./marking-types/table";
 
 export function MarkingTypesSettings() {
     const { t } = useTranslation();
-
-    const [selectedCategory, setSelectedCategory] = useState<
-        WORKING_MODE | undefined
-    >(undefined);
-
-    useEffect(() => {
-        invoke<WORKING_MODE | null>("get_working_mode").then(mode => {
-            if (mode) setSelectedCategory(mode);
-        });
-    }, []);
-
-    const types = MarkingTypesStore.use(state =>
-        selectedCategory
-            ? state.types.filter(c => c.category === selectedCategory)
-            : state.types
-    );
-
-    const setType = useDebouncedCallback((id, value) => {
-        MarkingTypesStore.actions.types.setType(id, value);
-        emitMarkingTypesChange();
-    }, 10);
-
-    const keybindings = KeybindingsStore.use(state =>
-        selectedCategory
-            ? state.typesKeybindings.filter(
-                  k => k.workingMode === selectedCategory
-              )
-            : state.typesKeybindings
-    );
-
-    const allKeybindings = KeybindingsStore.use(
-        state => state.typesKeybindings
-    );
-
-    useEffect(() => {
-        emitKeybindingsChange();
-    }, [allKeybindings]);
-
-    const workingModes = Object.values(WORKING_MODE);
-
-    const activeKeybindings = types
-        .map(item => keybindings.find(k => k.typeId === item.id))
-        .filter((k): k is NonNullable<typeof k> => !!k?.boundKey);
-
-    const conflictingKeys = new Set(
-        activeKeybindings
-            .filter((k, _, arr) =>
-                arr.some(
-                    other =>
-                        other.boundKey === k.boundKey &&
-                        other.typeId !== k.typeId
-                )
-            )
-            .map(k => k.boundKey)
-    );
+    const {
+        selectedCategory,
+        setSelectedCategory,
+        types,
+        setType,
+        keybindings,
+        conflictingKeys,
+        sensors,
+        handleDragEnd,
+        handleRemove,
+    } = useMarkingTypes();
 
     return (
         <div className="flex flex-col gap-4 p-2 h-full">
@@ -105,159 +23,17 @@ export function MarkingTypesSettings() {
                 <h2 className="text-lg font-semibold">
                     {t("Types", { ns: "keywords" })}
                 </h2>
-                <p className="text-sm text-muted-foreground">{t("Types")}</p>
+                <p className="text-sm text-muted-foreground">
+                    {t("Manage marking types", {
+                        ns: "description",
+                    })}
+                </p>
             </div>
 
-            <div className="flex justify-between items-center gap-2 flex-wrap">
-                <div className="flex flex-row gap-1.5 items-center">
-                    <DropdownMenu>
-                        <DropdownMenuTrigger
-                            className={cn(
-                                "h-8 px-3 flex items-center justify-between gap-2 min-w-[180px]",
-                                "border border-input rounded-md",
-                                "hover:bg-accent hover:text-accent-foreground"
-                            )}
-                        >
-                            <span className="text-sm">
-                                {selectedCategory ? (
-                                    t(selectedCategory, { ns: "modes" })
-                                ) : (
-                                    <span className="text-muted-foreground">
-                                        {t("Select working mode")}
-                                    </span>
-                                )}
-                            </span>
-                            <ChevronDown size={14} />
-                        </DropdownMenuTrigger>
-                        <DropdownMenuPortal>
-                            <DropdownMenuContent>
-                                {workingModes.map(mode => (
-                                    <DropdownMenuItem
-                                        key={mode}
-                                        onClick={() =>
-                                            setSelectedCategory(mode)
-                                        }
-                                    >
-                                        {t(mode, { ns: "modes" })}
-                                    </DropdownMenuItem>
-                                ))}
-                            </DropdownMenuContent>
-                        </DropdownMenuPortal>
-                    </DropdownMenu>
-
-                    <DropdownMenu>
-                        <DropdownMenuTrigger
-                            title={t("Add")}
-                            className={cn(
-                                "h-8 w-8 flex items-center justify-center",
-                                "border border-input rounded-md",
-                                "hover:bg-accent hover:text-accent-foreground",
-                                !selectedCategory &&
-                                    "opacity-50 cursor-not-allowed"
-                            )}
-                            disabled={!selectedCategory}
-                        >
-                            <Plus
-                                size={ICON.SIZE}
-                                strokeWidth={ICON.STROKE_WIDTH}
-                            />
-                        </DropdownMenuTrigger>
-
-                        <DropdownMenuPortal>
-                            <DropdownMenuContent>
-                                {(
-                                    Object.keys(
-                                        MARKING_CLASS
-                                    ) as (keyof typeof MARKING_CLASS)[]
-                                )
-                                    .filter(
-                                        key =>
-                                            MARKING_CLASS[key] !==
-                                            MARKING_CLASS.MEASUREMENT
-                                    )
-                                    .map(key => {
-                                        return (
-                                            <DropdownMenuItem
-                                                key={key}
-                                                onClick={() => {
-                                                    MarkingTypesStore.actions.types.add(
-                                                        {
-                                                            id: crypto.randomUUID(),
-                                                            name: t(
-                                                                `Marking.Keys.markingClass.Keys.${MARKING_CLASS[key]}`,
-                                                                {
-                                                                    ns: "object",
-                                                                }
-                                                            ),
-                                                            displayName: t(
-                                                                `Marking.Keys.markingClass.Keys.${MARKING_CLASS[key]}`,
-                                                                {
-                                                                    ns: "object",
-                                                                }
-                                                            ),
-                                                            markingClass:
-                                                                MARKING_CLASS[
-                                                                    key
-                                                                ],
-                                                            backgroundColor:
-                                                                defaultBackgroundColor,
-                                                            textColor:
-                                                                defaultTextColor,
-                                                            size: defaultSize,
-                                                            category:
-                                                                selectedCategory!,
-                                                        }
-                                                    );
-                                                    emitMarkingTypesChange();
-                                                }}
-                                            >
-                                                {t(
-                                                    `Marking.Keys.markingClass.Keys.${MARKING_CLASS[key]}`,
-                                                    { ns: "object" }
-                                                )}
-                                            </DropdownMenuItem>
-                                        );
-                                    })}
-                            </DropdownMenuContent>
-                        </DropdownMenuPortal>
-                    </DropdownMenu>
-
-                    <Toggle
-                        title={t("Import marking types", {
-                            ns: "tooltip",
-                        })}
-                        size="icon"
-                        variant="outline"
-                        className="h-8 w-8"
-                        pressed={false}
-                        onClickCapture={async () => {
-                            await importMarkingTypesWithDialog();
-                            emitMarkingTypesChange();
-                        }}
-                    >
-                        <Download
-                            size={ICON.SIZE}
-                            strokeWidth={ICON.STROKE_WIDTH}
-                        />
-                    </Toggle>
-
-                    <Toggle
-                        title={t("Export marking types", {
-                            ns: "tooltip",
-                        })}
-                        size="icon"
-                        variant="outline"
-                        className="h-8 w-8"
-                        pressed={false}
-                        onClickCapture={() => exportMarkingTypesWithDialog()}
-                    >
-                        <Upload
-                            size={ICON.SIZE}
-                            strokeWidth={ICON.STROKE_WIDTH}
-                        />
-                    </Toggle>
-                </div>
-            </div>
+            <MarkingTypesToolbar
+                selectedCategory={selectedCategory}
+                onSelectCategory={setSelectedCategory}
+            />
 
             {selectedCategory !== undefined && conflictingKeys.size > 0 && (
                 <p className="text-sm text-destructive">
@@ -266,229 +42,16 @@ export function MarkingTypesSettings() {
             )}
 
             <div className="flex-1 overflow-auto">
-                {selectedCategory === undefined ? (
-                    <div className="flex flex-col items-center text-center gap-2 border border-dashed py-8 rounded-lg">
-                        <LayoutGrid className="size-12" />
-                        <p>
-                            {t("Select a working mode to view marking types")}
-                        </p>
-                    </div>
-                ) : (
-                    <table className="w-full">
-                        <thead className="sticky top-0 bg-card">
-                            <TableRow className={cn("bg-card border-b")}>
-                                <TableHead className="text-center text-card-foreground whitespace-nowrap">
-                                    {t(`MarkingType.Keys.displayName`, {
-                                        ns: "object",
-                                    })}
-                                </TableHead>
-                                <TableHead className="text-center text-card-foreground whitespace-nowrap">
-                                    {t(`MarkingType.Keys.name`, {
-                                        ns: "object",
-                                    })}
-                                </TableHead>
-                                <TableHead className="text-center text-card-foreground whitespace-nowrap">
-                                    {t(`MarkingType.Keys.markingClass`, {
-                                        ns: "object",
-                                    })}
-                                </TableHead>
-                                <TableHead className="text-center text-card-foreground whitespace-nowrap">
-                                    {t(`MarkingType.Keys.backgroundColor`, {
-                                        ns: "object",
-                                    })}
-                                </TableHead>
-                                <TableHead className="text-center text-card-foreground whitespace-nowrap">
-                                    {t(`MarkingType.Keys.textColor`, {
-                                        ns: "object",
-                                    })}
-                                </TableHead>
-                                <TableHead className="text-center text-card-foreground whitespace-nowrap">
-                                    {t(`MarkingType.Keys.size`, {
-                                        ns: "object",
-                                    })}
-                                </TableHead>
-                                <TableHead className="text-center text-card-foreground whitespace-nowrap">
-                                    {t("Keybinding", { ns: "keybindings" })}
-                                </TableHead>
-                                {IS_DEV_ENVIRONMENT && <TableHead />}
-                            </TableRow>
-                        </thead>
-                        <tbody>
-                            {types.length === 0 ? (
-                                <TableRow>
-                                    <TableCell
-                                        colSpan={8}
-                                        className="text-center py-8 text-muted-foreground"
-                                    >
-                                        {t(
-                                            "No marking types found for the selected working mode"
-                                        )}
-                                    </TableCell>
-                                </TableRow>
-                            ) : (
-                                types.map(item => {
-                                    const itemBoundKey = keybindings.find(
-                                        k => k.typeId === item.id
-                                    )?.boundKey;
-                                    return (
-                                        <TableRow key={item.id}>
-                                            <TableCell>
-                                                <Input
-                                                    className="h-6 !p-0 text-center"
-                                                    title={`${t("MarkingType.Keys.name", { ns: "object" })}`}
-                                                    type="text"
-                                                    value={item.displayName}
-                                                    onChange={e => {
-                                                        setType(item.id, {
-                                                            displayName:
-                                                                e.target.value,
-                                                        });
-                                                    }}
-                                                />
-                                            </TableCell>
-                                            <TableCell>
-                                                {IS_DEV_ENVIRONMENT ? (
-                                                    <Input
-                                                        className="h-6 !p-0 text-center"
-                                                        title={`${t("MarkingType.Keys.name", { ns: "object" })}`}
-                                                        type="text"
-                                                        value={item.name}
-                                                        onChange={e => {
-                                                            setType(item.id, {
-                                                                name: e.target
-                                                                    .value,
-                                                            });
-                                                        }}
-                                                    />
-                                                ) : (
-                                                    <span className="p-1 cursor-default">
-                                                        {item.name}
-                                                    </span>
-                                                )}
-                                            </TableCell>
-                                            <TableCell
-                                                className={cn(
-                                                    "p-1 cursor-default text-center"
-                                                )}
-                                            >
-                                                {t(
-                                                    `Marking.Keys.markingClass.Keys.${item.markingClass}`,
-                                                    {
-                                                        ns: "object",
-                                                    }
-                                                )}
-                                            </TableCell>
-                                            <TableCell>
-                                                <Input
-                                                    className="size-6 cursor-pointer m-auto"
-                                                    title={`${t("MarkingType.Keys.backgroundColor", { ns: "object" })}`}
-                                                    type="color"
-                                                    value={
-                                                        item.backgroundColor as string
-                                                    }
-                                                    onChange={e => {
-                                                        setType(item.id, {
-                                                            backgroundColor:
-                                                                e.target.value,
-                                                        });
-                                                    }}
-                                                />
-                                            </TableCell>
-                                            <TableCell>
-                                                <Input
-                                                    className="size-6 cursor-pointer m-auto"
-                                                    title={`${t("MarkingType.Keys.textColor", { ns: "object" })}`}
-                                                    type="color"
-                                                    value={
-                                                        item.textColor as string
-                                                    }
-                                                    onChange={e => {
-                                                        setType(item.id, {
-                                                            textColor:
-                                                                e.target.value,
-                                                        });
-                                                    }}
-                                                />
-                                            </TableCell>
-                                            <TableCell>
-                                                <Input
-                                                    className="w-24 h-6 !p-0 text-center m-auto"
-                                                    min={6}
-                                                    max={32}
-                                                    width={12}
-                                                    title={`${t("MarkingType.Keys.size", { ns: "object" })}`}
-                                                    type="number"
-                                                    value={item.size}
-                                                    onChange={e => {
-                                                        setType(item.id, {
-                                                            size: Number(
-                                                                e.target.value
-                                                            ),
-                                                        });
-                                                    }}
-                                                />
-                                            </TableCell>
-                                            <TableCell>
-                                                <TypeKeybinding
-                                                    boundKey={itemBoundKey}
-                                                    workingMode={item.category}
-                                                    typeId={item.id}
-                                                    isConflict={
-                                                        !!itemBoundKey &&
-                                                        conflictingKeys.has(
-                                                            itemBoundKey
-                                                        )
-                                                    }
-                                                />
-                                            </TableCell>
-                                            {IS_DEV_ENVIRONMENT && (
-                                                <TableCell>
-                                                    <Toggle
-                                                        title={t("Remove")}
-                                                        className="m-auto"
-                                                        size="icon"
-                                                        variant="outline"
-                                                        pressed={false}
-                                                        disabled={
-                                                            MarkingTypesStore.actions.types.checkIfTypeIsInUse(
-                                                                item.id,
-                                                                CANVAS_ID.LEFT
-                                                            ) ||
-                                                            MarkingTypesStore.actions.types.checkIfTypeIsInUse(
-                                                                item.id,
-                                                                CANVAS_ID.RIGHT
-                                                            )
-                                                        }
-                                                        onClickCapture={() => {
-                                                            MarkingTypesStore.actions.types.removeById(
-                                                                item.id
-                                                            );
-
-                                                            KeybindingsStore.actions.typesKeybindings.remove(
-                                                                item.id,
-                                                                item.category
-                                                            );
-
-                                                            emitMarkingTypesChange();
-                                                        }}
-                                                    >
-                                                        <Trash2
-                                                            className="hover:text-destructive"
-                                                            size={ICON.SIZE}
-                                                            strokeWidth={
-                                                                ICON.STROKE_WIDTH
-                                                            }
-                                                        />
-                                                    </Toggle>
-                                                </TableCell>
-                                            )}
-                                        </TableRow>
-                                    );
-                                })
-                            )}
-                        </tbody>
-                    </table>
-                )}
+                <MarkingTypesTable
+                    selectedCategory={selectedCategory}
+                    types={types}
+                    keybindings={keybindings}
+                    conflictingKeys={conflictingKeys}
+                    sensors={sensors}
+                    onDragEnd={handleDragEnd}
+                    onRemove={handleRemove}
+                    setType={setType}
+                />
             </div>
         </div>
     );

--- a/src/components/settings-window/categories/marking-types/row.tsx
+++ b/src/components/settings-window/categories/marking-types/row.tsx
@@ -1,0 +1,167 @@
+import { cn } from "@/lib/utils/shadcn";
+import { Input } from "@/components/ui/input";
+import { useTranslation } from "react-i18next";
+import { TableCell, TableRow } from "@/components/ui/table";
+import { Trash2, GripVertical } from "lucide-react";
+import { ICON } from "@/lib/utils/const";
+import { Toggle } from "@/components/ui/toggle";
+import { CANVAS_ID } from "@/components/pixi/canvas/hooks/useCanvasContext";
+import TypeKeybinding from "@/components/dialogs/marking-types/marking-type-keybinding";
+import { MarkingTypesStore } from "@/lib/stores/MarkingTypes/MarkingTypes";
+import { MarkingType } from "@/lib/markings/MarkingType";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+
+export interface SortableTypeRowProps {
+    item: MarkingType;
+    boundKey: string | undefined;
+    isConflict: boolean;
+    setType: (id: string, value: Partial<MarkingType>) => void;
+    onRemove: (item: MarkingType) => void;
+}
+
+export function SortableTypeRow({
+    item,
+    boundKey,
+    isConflict,
+    setType,
+    onRemove,
+}: SortableTypeRowProps) {
+    const { t } = useTranslation();
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        transform,
+        transition,
+        isDragging,
+    } = useSortable({ id: item.id });
+
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+    };
+
+    return (
+        <TableRow
+            ref={setNodeRef}
+            style={style}
+            className={cn(isDragging && "opacity-40 z-10 relative")}
+        >
+            <TableCell className="w-6 px-1">
+                <button
+                    type="button"
+                    aria-label={t("Drag to reorder", { ns: "tooltip" })}
+                    title={`${t("Move up", { ns: "tooltip" })} / ${t("Move down", { ns: "tooltip" })}`}
+                    className="flex text-muted-foreground/50 cursor-grab active:cursor-grabbing select-none touch-none rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                    {...attributes}
+                    {...listeners}
+                >
+                    <GripVertical
+                        size={ICON.SIZE}
+                        strokeWidth={ICON.STROKE_WIDTH}
+                    />
+                </button>
+            </TableCell>
+            <TableCell>
+                <Input
+                    className="h-6 !p-0 text-center"
+                    title={`${t("MarkingType.Keys.displayName", { ns: "object" })}`}
+                    type="text"
+                    value={item.displayName}
+                    onChange={e =>
+                        setType(item.id, { displayName: e.target.value })
+                    }
+                />
+            </TableCell>
+            {/* <TableCell>
+                {IS_DEV_ENVIRONMENT ? (
+                    <Input
+                        className="h-6 !p-0 text-center"
+                        title={`${t("MarkingType.Keys.name", { ns: "object" })}`}
+                        type="text"
+                        value={item.name}
+                        onChange={e => setType(item.id, { name: e.target.value })}
+                    />
+                ) : (
+                    <span className="p-1 cursor-default">{item.name}</span>
+                )}
+            </TableCell> */}
+            <TableCell className="p-1 cursor-default text-center">
+                {t(`Marking.Keys.markingClass.Keys.${item.markingClass}`, {
+                    ns: "object",
+                })}
+            </TableCell>
+            <TableCell>
+                <Input
+                    className="size-6 cursor-pointer m-auto"
+                    title={`${t("MarkingType.Keys.backgroundColor", { ns: "object" })}`}
+                    type="color"
+                    value={item.backgroundColor as string}
+                    onChange={e =>
+                        setType(item.id, { backgroundColor: e.target.value })
+                    }
+                />
+            </TableCell>
+            <TableCell>
+                <Input
+                    className="size-6 cursor-pointer m-auto"
+                    title={`${t("MarkingType.Keys.textColor", { ns: "object" })}`}
+                    type="color"
+                    value={item.textColor as string}
+                    onChange={e =>
+                        setType(item.id, { textColor: e.target.value })
+                    }
+                />
+            </TableCell>
+            <TableCell>
+                <Input
+                    className="w-24 h-6 !p-0 text-center m-auto"
+                    min={6}
+                    max={32}
+                    width={12}
+                    title={`${t("MarkingType.Keys.size", { ns: "object" })}`}
+                    type="number"
+                    value={item.size}
+                    onChange={e =>
+                        setType(item.id, { size: Number(e.target.value) })
+                    }
+                />
+            </TableCell>
+            <TableCell>
+                <TypeKeybinding
+                    boundKey={boundKey}
+                    workingMode={item.category}
+                    typeId={item.id}
+                    isConflict={isConflict}
+                />
+            </TableCell>
+            <TableCell>
+                <Toggle
+                    title={t("Remove")}
+                    className="m-auto"
+                    size="icon"
+                    variant="outline"
+                    pressed={false}
+                    disabled={
+                        MarkingTypesStore.actions.types.checkIfTypeIsInUse(
+                            item.id,
+                            CANVAS_ID.LEFT
+                        ) ||
+                        MarkingTypesStore.actions.types.checkIfTypeIsInUse(
+                            item.id,
+                            CANVAS_ID.RIGHT
+                        )
+                    }
+                    onClickCapture={() => onRemove(item)}
+                >
+                    <Trash2
+                        className="hover:text-destructive"
+                        size={ICON.SIZE}
+                        strokeWidth={ICON.STROKE_WIDTH}
+                    />
+                </Toggle>
+            </TableCell>
+        </TableRow>
+    );
+}

--- a/src/components/settings-window/categories/marking-types/table.tsx
+++ b/src/components/settings-window/categories/marking-types/table.tsx
@@ -1,0 +1,129 @@
+import { cn } from "@/lib/utils/shadcn";
+import { useTranslation } from "react-i18next";
+import { TableCell, TableHead, TableRow } from "@/components/ui/table";
+import { LayoutGrid } from "lucide-react";
+import { MarkingType } from "@/lib/markings/MarkingType";
+import { TypeKeybinding } from "@/lib/stores/Keybindings";
+import { WORKING_MODE } from "@/views/selectMode";
+import {
+    DndContext,
+    DragEndEvent,
+    closestCenter,
+    useSensors,
+} from "@dnd-kit/core";
+import {
+    SortableContext,
+    verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { SortableTypeRow } from "./row";
+
+interface MarkingTypesTableProps {
+    selectedCategory: WORKING_MODE | undefined;
+    types: MarkingType[];
+    keybindings: TypeKeybinding[];
+    conflictingKeys: Set<string>;
+    sensors: ReturnType<typeof useSensors>;
+    onDragEnd: (event: DragEndEvent) => void;
+    onRemove: (item: MarkingType) => void;
+    setType: (id: string, value: Partial<MarkingType>) => void;
+}
+
+export function MarkingTypesTable({
+    selectedCategory,
+    types,
+    keybindings,
+    conflictingKeys,
+    sensors,
+    onDragEnd,
+    onRemove,
+    setType,
+}: MarkingTypesTableProps) {
+    const { t } = useTranslation();
+
+    if (selectedCategory === undefined) {
+        return (
+            <div className="flex flex-col items-center text-center gap-2 border border-dashed py-8 rounded-lg">
+                <LayoutGrid className="size-12" />
+                <p>{t("Select a working mode to view marking types")}</p>
+            </div>
+        );
+    }
+
+    return (
+        <table className="w-full">
+            <thead className="sticky top-0 bg-card">
+                <TableRow className={cn("bg-card border-b")}>
+                    <TableHead className="w-6" />
+                    <TableHead className="text-center text-card-foreground whitespace-nowrap">
+                        {t(`MarkingType.Keys.displayName`, { ns: "object" })}
+                    </TableHead>
+                    {/* <TableHead className="text-center text-card-foreground whitespace-nowrap">
+                        {t(`MarkingType.Keys.name`, { ns: "object" })}
+                    </TableHead> */}
+                    <TableHead className="text-center text-card-foreground whitespace-nowrap">
+                        {t(`MarkingType.Keys.markingClass`, { ns: "object" })}
+                    </TableHead>
+                    <TableHead className="text-center text-card-foreground whitespace-nowrap">
+                        {t(`MarkingType.Keys.backgroundColor`, {
+                            ns: "object",
+                        })}
+                    </TableHead>
+                    <TableHead className="text-center text-card-foreground whitespace-nowrap">
+                        {t(`MarkingType.Keys.textColor`, { ns: "object" })}
+                    </TableHead>
+                    <TableHead className="text-center text-card-foreground whitespace-nowrap">
+                        {t(`MarkingType.Keys.size`, { ns: "object" })}
+                    </TableHead>
+                    <TableHead className="text-center text-card-foreground whitespace-nowrap">
+                        {t("Keybinding", { ns: "keybindings" })}
+                    </TableHead>
+                    <TableHead className="w-8" />
+                </TableRow>
+            </thead>
+            <tbody>
+                {types.length === 0 ? (
+                    <TableRow>
+                        <TableCell
+                            colSpan={9}
+                            className="text-center py-8 text-muted-foreground"
+                        >
+                            {t(
+                                "No marking types found for the selected working mode"
+                            )}
+                        </TableCell>
+                    </TableRow>
+                ) : (
+                    <DndContext
+                        sensors={sensors}
+                        collisionDetection={closestCenter}
+                        onDragEnd={onDragEnd}
+                    >
+                        <SortableContext
+                            items={types.map(t => t.id)}
+                            strategy={verticalListSortingStrategy}
+                        >
+                            {types.map(item => {
+                                const itemBoundKey = keybindings.find(
+                                    k => k.typeId === item.id
+                                )?.boundKey;
+                                return (
+                                    <SortableTypeRow
+                                        key={item.id}
+                                        item={item}
+                                        boundKey={itemBoundKey}
+                                        isConflict={
+                                            !!itemBoundKey &&
+                                            conflictingKeys.has(itemBoundKey)
+                                        }
+                                        setType={setType}
+                                        onRemove={onRemove}
+                                    />
+                                );
+                            })}
+                        </SortableContext>
+                    </DndContext>
+                )}
+            </tbody>
+        </table>
+    );
+}

--- a/src/components/settings-window/categories/marking-types/toolbar.tsx
+++ b/src/components/settings-window/categories/marking-types/toolbar.tsx
@@ -1,0 +1,157 @@
+import { cn } from "@/lib/utils/shadcn";
+import { useTranslation } from "react-i18next";
+import { Toggle } from "@/components/ui/toggle";
+import { WORKING_MODE } from "@/views/selectMode";
+import { MarkingTypesStore } from "@/lib/stores/MarkingTypes/MarkingTypes";
+import { exportMarkingTypesWithDialog } from "@/components/dialogs/marking-types/exportMarkingTypesWithDialog";
+import { importMarkingTypesWithDialog } from "@/components/dialogs/marking-types/importMarkingTypesWithDialog";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuPortal,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { MARKING_CLASS } from "@/lib/markings/MARKING_CLASS";
+import {
+    defaultBackgroundColor,
+    defaultSize,
+    defaultTextColor,
+} from "@/lib/markings/MarkingType";
+import { ICON } from "@/lib/utils/const";
+import { ChevronDown, Download, Plus, Upload } from "lucide-react";
+import { emitMarkingTypesChange } from "@/lib/hooks/useSettingsSync";
+
+interface MarkingTypesToolbarProps {
+    selectedCategory: WORKING_MODE | undefined;
+    onSelectCategory: (mode: WORKING_MODE) => void;
+}
+
+export function MarkingTypesToolbar({
+    selectedCategory,
+    onSelectCategory,
+}: MarkingTypesToolbarProps) {
+    const { t } = useTranslation();
+    const workingModes = Object.values(WORKING_MODE);
+
+    return (
+        <div className="flex flex-row gap-1.5 items-center">
+            <DropdownMenu>
+                <DropdownMenuTrigger
+                    className={cn(
+                        "h-8 px-3 flex items-center justify-between gap-2 min-w-[180px]",
+                        "border border-input rounded-md",
+                        "hover:bg-accent hover:text-accent-foreground"
+                    )}
+                >
+                    <span className="text-sm">
+                        {selectedCategory ? (
+                            t(selectedCategory, { ns: "modes" })
+                        ) : (
+                            <span className="text-muted-foreground">
+                                {t("Select working mode")}
+                            </span>
+                        )}
+                    </span>
+                    <ChevronDown size={14} />
+                </DropdownMenuTrigger>
+                <DropdownMenuPortal>
+                    <DropdownMenuContent>
+                        {workingModes.map(mode => (
+                            <DropdownMenuItem
+                                key={mode}
+                                onClick={() => onSelectCategory(mode)}
+                            >
+                                {t(mode, { ns: "modes" })}
+                            </DropdownMenuItem>
+                        ))}
+                    </DropdownMenuContent>
+                </DropdownMenuPortal>
+            </DropdownMenu>
+
+            <DropdownMenu>
+                <DropdownMenuTrigger
+                    title={t("Add")}
+                    className={cn(
+                        "h-8 w-8 flex items-center justify-center",
+                        "border border-input rounded-md",
+                        "hover:bg-accent hover:text-accent-foreground",
+                        !selectedCategory && "opacity-50 cursor-not-allowed"
+                    )}
+                    disabled={!selectedCategory}
+                >
+                    <Plus size={ICON.SIZE} strokeWidth={ICON.STROKE_WIDTH} />
+                </DropdownMenuTrigger>
+                <DropdownMenuPortal>
+                    <DropdownMenuContent>
+                        {(
+                            Object.keys(
+                                MARKING_CLASS
+                            ) as (keyof typeof MARKING_CLASS)[]
+                        )
+                            .filter(
+                                key =>
+                                    MARKING_CLASS[key] !==
+                                    MARKING_CLASS.MEASUREMENT
+                            )
+                            .map(key => (
+                                <DropdownMenuItem
+                                    key={key}
+                                    onClick={() => {
+                                        MarkingTypesStore.actions.types.add({
+                                            id: crypto.randomUUID(),
+                                            name: t(
+                                                `Marking.Keys.markingClass.Keys.${MARKING_CLASS[key]}`,
+                                                { ns: "object" }
+                                            ),
+                                            displayName: t(
+                                                `Marking.Keys.markingClass.Keys.${MARKING_CLASS[key]}`,
+                                                { ns: "object" }
+                                            ),
+                                            markingClass: MARKING_CLASS[key],
+                                            backgroundColor:
+                                                defaultBackgroundColor,
+                                            textColor: defaultTextColor,
+                                            size: defaultSize,
+                                            category: selectedCategory!,
+                                        });
+                                        emitMarkingTypesChange();
+                                    }}
+                                >
+                                    {t(
+                                        `Marking.Keys.markingClass.Keys.${MARKING_CLASS[key]}`,
+                                        { ns: "object" }
+                                    )}
+                                </DropdownMenuItem>
+                            ))}
+                    </DropdownMenuContent>
+                </DropdownMenuPortal>
+            </DropdownMenu>
+
+            <Toggle
+                title={t("Import marking types", { ns: "tooltip" })}
+                size="icon"
+                variant="outline"
+                className="h-8 w-8"
+                pressed={false}
+                onClickCapture={async () => {
+                    await importMarkingTypesWithDialog();
+                    emitMarkingTypesChange();
+                }}
+            >
+                <Download size={ICON.SIZE} strokeWidth={ICON.STROKE_WIDTH} />
+            </Toggle>
+
+            <Toggle
+                title={t("Export marking types", { ns: "tooltip" })}
+                size="icon"
+                variant="outline"
+                className="h-8 w-8"
+                pressed={false}
+                onClickCapture={() => exportMarkingTypesWithDialog()}
+            >
+                <Upload size={ICON.SIZE} strokeWidth={ICON.STROKE_WIDTH} />
+            </Toggle>
+        </div>
+    );
+}

--- a/src/components/settings-window/categories/marking-types/use-marking-types.ts
+++ b/src/components/settings-window/categories/marking-types/use-marking-types.ts
@@ -1,0 +1,112 @@
+import { useState, useEffect } from "react";
+import { useDebouncedCallback } from "use-debounce";
+import {
+    PointerSensor,
+    useSensor,
+    useSensors,
+    DragEndEvent,
+} from "@dnd-kit/core";
+import { invoke } from "@tauri-apps/api/core";
+import { MarkingTypesStore } from "@/lib/stores/MarkingTypes/MarkingTypes";
+import { KeybindingsStore, TypeKeybinding } from "@/lib/stores/Keybindings";
+import { MarkingType } from "@/lib/markings/MarkingType";
+import { WORKING_MODE } from "@/views/selectMode";
+import {
+    emitMarkingTypesChange,
+    emitKeybindingsChange,
+} from "@/lib/hooks/useSettingsSync";
+
+export function useMarkingTypes() {
+    const [selectedCategory, setSelectedCategory] = useState<
+        WORKING_MODE | undefined
+    >(undefined);
+
+    useEffect(() => {
+        invoke<WORKING_MODE | null>("get_working_mode").then(mode => {
+            if (mode) setSelectedCategory(mode);
+        });
+    }, []);
+
+    const types = MarkingTypesStore.use(state =>
+        selectedCategory
+            ? state.types.filter(c => c.category === selectedCategory)
+            : state.types
+    );
+
+    const setType = useDebouncedCallback(
+        (id: string, value: Partial<MarkingType>) => {
+            MarkingTypesStore.actions.types.setType(id, value);
+            emitMarkingTypesChange();
+        },
+        10
+    );
+
+    const keybindings = KeybindingsStore.use(state =>
+        selectedCategory
+            ? state.typesKeybindings.filter(
+                  k => k.workingMode === selectedCategory
+              )
+            : state.typesKeybindings
+    );
+
+    const allKeybindings = KeybindingsStore.use(
+        state => state.typesKeybindings
+    );
+
+    useEffect(() => {
+        emitKeybindingsChange();
+    }, [allKeybindings]);
+
+    const activeKeybindings = types
+        .map(item => keybindings.find(k => k.typeId === item.id))
+        .filter((k): k is NonNullable<typeof k> => !!k?.boundKey);
+
+    const conflictingKeys = new Set(
+        activeKeybindings
+            .filter((k, _, arr) =>
+                arr.some(
+                    other =>
+                        other.boundKey === k.boundKey &&
+                        other.typeId !== k.typeId
+                )
+            )
+            .map(k => k.boundKey)
+    );
+
+    const sensors = useSensors(useSensor(PointerSensor));
+
+    function handleDragEnd(event: DragEndEvent) {
+        const { active, over } = event;
+        if (!over || active.id === over.id) return;
+        const fromIdx = types.findIndex(t => t.id === active.id);
+        const toIdx = types.findIndex(t => t.id === over.id);
+        if (fromIdx === -1 || toIdx === -1) return;
+        MarkingTypesStore.actions.types.reorder(
+            fromIdx,
+            toIdx,
+            selectedCategory!
+        );
+        emitMarkingTypesChange();
+    }
+
+    function handleRemove(item: MarkingType) {
+        MarkingTypesStore.actions.types.removeById(item.id);
+        KeybindingsStore.actions.typesKeybindings.remove(
+            item.id,
+            item.category
+        );
+        emitMarkingTypesChange();
+    }
+
+    return {
+        selectedCategory,
+        setSelectedCategory,
+        types,
+        setType,
+        keybindings: keybindings as TypeKeybinding[],
+        conflictingKeys,
+        sensors,
+        handleDragEnd,
+        handleRemove,
+    };
+}

--- a/src/lib/locales/en/description.ts
+++ b/src/lib/locales/en/description.ts
@@ -12,6 +12,7 @@ const d: Dictionary = {
     "Configure report metadata": "Configure report metadata",
     "Configure default report data": "Configure default report data",
     "Generate PDF report": "Generate PDF report",
+    "Manage marking types": "Manage marking types",
 };
 
 export default d;

--- a/src/lib/locales/pl/description.ts
+++ b/src/lib/locales/pl/description.ts
@@ -10,9 +10,9 @@ const d: Dictionary = {
     "Create and manage custom color themes":
         "Tw\u00f3rz i zarz\u0105dzaj w\u0142asnymi motywami kolorystycznymi",
     "Configure report metadata": "Skonfiguruj metadane raportu",
-    "Configure default report data":
-        "Ustaw domy\u015blne dane raportu",
+    "Configure default report data": "Ustaw domy\u015blne dane raportu",
     "Generate PDF report": "Wygeneruj raport PDF",
+    "Manage marking types": "Zarządzaj typami oznaczeń",
 };
 
 export default d;

--- a/src/lib/locales/translation.ts
+++ b/src/lib/locales/translation.ts
@@ -101,6 +101,7 @@ export type i18nDescription = Recordify<
     | "Configure report metadata"
     | "Configure default report data"
     | "Generate PDF report"
+    | "Manage marking types"
 >;
 
 export type i18nModes = Recordify<WORKING_MODE>;

--- a/src/lib/stores/MarkingTypes/MarkingTypes.ts
+++ b/src/lib/stores/MarkingTypes/MarkingTypes.ts
@@ -67,6 +67,35 @@ class StoreClass {
 
                 this.actions.selectedType.set(null);
             },
+            reorder: (fromIdx: number, toIdx: number, category: string) => {
+                this.state.set(draft => {
+                    const catItems = draft.types.filter(
+                        t => t.category === category
+                    );
+
+                    if (
+                        fromIdx < 0 ||
+                        toIdx < 0 ||
+                        fromIdx >= catItems.length ||
+                        toIdx >= catItems.length
+                    )
+                        return;
+
+                    const moved = catItems.splice(fromIdx, 1)[0] as MarkingType;
+                    catItems.splice(toIdx, 0, moved);
+
+                    let catIdx = 0;
+                    for (let i = 0; i < draft.types.length; i += 1) {
+                        const current = draft.types[`${i}`];
+                        if (current && current.category === category) {
+                            draft.types[`${i}`] = catItems[
+                                `${catIdx}`
+                            ] as MarkingType;
+                            catIdx += 1;
+                        }
+                    }
+                });
+            },
             setType: (
                 typeId: MarkingType["id"],
                 newValues: Partial<MarkingType>


### PR DESCRIPTION
  - Extracted marking-types-settings into subcomponents (toolbar, table, row, hook)
  - Added delete button for marking types (previously dev-only)
  - Added drag-and-drop reordering via @dnd-kit/sortable
  - Updated subtitle for the marking types settings tab